### PR TITLE
Added mkdir autoconfig in Makefile to avoid copy issue when it does n…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ copy-configuration:
 	npx hardhat run scripts/setSubgraphNetwork.ts --network $(DEPLOY_NETWORK)
 else
 copy-configuration: 
+	[ -d "$(DAPP_FOLDER)/src/autoconfig/" ] || mkdir "$(DAPP_FOLDER)/src/autoconfig/" 
 	cp "$(CONTRACTS_FOLDER)/talent.config_$(DEPLOY_NETWORK).json" "$(DAPP_FOLDER)/src/autoconfig/talent.config_$(DEPLOY_NETWORK).json"
 	npx hardhat run scripts/setSubgraphNetwork.ts --network $(DEPLOY_NETWORK)
 endif


### PR DESCRIPTION
Small suggested change to make the makefile run on unix without crashing if the autoconfig folder does not exist.