### PR TITLE
Clean serviceRegistry contract workflow

### DIFF
--- a/test/batch/TalentLayer.ts
+++ b/test/batch/TalentLayer.ts
@@ -4,7 +4,8 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { Contract, ContractFactory } from 'ethers'
 import { TalentLayerID } from '../../typechain-types'
 
-describe('TalentLayer', function() {
+describe('TalentLayer', function () {
+  // we dedine the types of the variables we will use
   let deployer: SignerWithAddress,
     alice: SignerWithAddress,
     bob: SignerWithAddress,
@@ -31,7 +32,8 @@ describe('TalentLayer', function() {
     platformId: string,
     mintFee: number
 
-  before(async function() {
+  before(async function () {
+    // Get the Signers
     ;[deployer, alice, bob, carol, dave, eve] = await ethers.getSigners()
 
     // Deploy MockProofOfHumanity
@@ -97,22 +99,21 @@ describe('TalentLayer', function() {
     // Deployer mints Platform Id for Alice
     platformName = 'HireVibes'
     await talentLayerPlatformID.connect(deployer).mintForAddress(platformName, alice.address)
-
     mintFee = 100
   })
 
-  describe('Platform Id contract test', async function() {
-    it('Alice successfully minted a PlatformId Id', async function() {
+  describe('Platform Id contract test', async function () {
+    it('Alice successfully minted a PlatformId Id', async function () {
       platformId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       expect(platformId).to.be.equal('1')
     })
 
-    it('Alice can check the number of id minted', async function() {
+    it('Alice can check the number of id minted', async function () {
       await talentLayerPlatformID.connect(alice).numberMinted(alice.address)
       expect(await talentLayerPlatformID.numberMinted(alice.address)).to.be.equal('1')
     })
 
-    it('Alice can update the platform Data', async function() {
+    it('Alice can update the platform Data', async function () {
       await talentLayerPlatformID.connect(alice).updateProfileData('1', 'newPlatId')
 
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
@@ -120,28 +121,28 @@ describe('TalentLayer', function() {
       expect(alicePlatformData.dataUri).to.be.equal('newPlatId')
     })
 
-    it('Alice should not be able to transfer her PlatformId Id to Bob', async function() {
+    it('Alice should not be able to transfer her PlatformId Id to Bob', async function () {
       expect(talentLayerPlatformID.transferFrom(alice.address, bob.address, 1)).to.be.revertedWith('Not allowed')
     })
 
-    it('Alice should not be able to mint a new PlatformId ID', async function() {
+    it('Alice should not be able to mint a new PlatformId ID', async function () {
       expect(talentLayerPlatformID.connect(alice).mint('SecPlatId')).to.be.revertedWith(
         'You already have a Platform ID',
       )
     })
 
-    it('ALice can\'t mint a platformId for someone else', async function() {
+    it("ALice can't mint a platformId for someone else", async function () {
       const mintRole = await talentLayerPlatformID.MINT_ROLE()
       expect(talentLayerPlatformID.connect(alice).mintForAddress('platId2', dave.address)).to.be.revertedWith(
-        `Error: VM Exception while processing transaction: reverted with reason string 'AccessControl: account ${alice.address.toLowerCase()} is missing role ${mintRole.toLowerCase()}'`)
+        `Error: VM Exception while processing transaction: reverted with reason string 'AccessControl: account ${alice.address.toLowerCase()} is missing role ${mintRole.toLowerCase()}'`,
+      )
     })
 
-
-    it('Alice should not be able to mint a PlatformId ID with the same name', async function() {
+    it('Alice should not be able to mint a PlatformId ID with the same name', async function () {
       expect(talentLayerPlatformID.connect(alice).mint('PlatId')).to.be.revertedWith('You already have a Platform ID')
     })
 
-    it("Alice's PlatformID ownership data is coherent", async function() {
+    it("Alice's PlatformID ownership data is coherent", async function () {
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
       const name = alicePlatformData.name
@@ -153,7 +154,7 @@ describe('TalentLayer', function() {
       expect(idOwner).to.equal(alice.address)
     })
 
-    it('Alice should be able to set up and update platform fee', async function() {
+    it('Alice should be able to set up and update platform fee', async function () {
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       const adminRole = await talentLayerPlatformID.DEFAULT_ADMIN_ROLE()
 
@@ -171,14 +172,14 @@ describe('TalentLayer', function() {
       expect(newAlicePlatformData.fee).to.be.equal(6)
     })
 
-    it('The deployer can update the mint fee', async function() {
+    it('The deployer can update the mint fee', async function () {
       await talentLayerPlatformID.connect(deployer).updateMintFee(mintFee)
       const updatedMintFee = await talentLayerPlatformID.mintFee()
 
       expect(updatedMintFee).to.be.equal(mintFee)
     })
 
-    it('Bob can mint a platform id by paying the mint fee', async function() {
+    it('Bob can mint a platform id by paying the mint fee', async function () {
       const bobBalanceBefore = await bob.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerPlatformID.address)
 
@@ -201,7 +202,7 @@ describe('TalentLayer', function() {
       expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
     })
 
-    it("The deployer can withdraw the contract's balance", async function() {
+    it("The deployer can withdraw the contract's balance", async function () {
       const deployerBalanceBefore = await deployer.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerPlatformID.address)
 
@@ -224,361 +225,111 @@ describe('TalentLayer', function() {
     })
   })
 
-  it('Alice, Bob and Carol can mint a talentLayerId', async function() {
-    await talentLayerID.connect(alice).mintWithPoh('1', 'alice')
-    await talentLayerID.connect(bob).mintWithPoh('1', 'bob')
+  describe('Talent Layer ID contract test', function () {
+    it('Alice, Bob and Carol can mint a talentLayerId', async function () {
+      await talentLayerID.connect(alice).mintWithPoh('1', 'alice')
+      await talentLayerID.connect(bob).mintWithPoh('1', 'bob')
 
-    expect(talentLayerID.connect(carol).mintWithPoh('1', 'carol')).to.be.revertedWith(
-      'You need to use an address registered on Proof of Humanity',
-    )
-    await talentLayerID.connect(carol).mint('1', 'carol')
-    expect(await talentLayerID.walletOfOwner(alice.address)).to.be.equal('1')
-    expect(await talentLayerID.walletOfOwner(bob.address)).to.be.equal('2')
-    expect(await talentLayerID.walletOfOwner(carol.address)).to.be.equal('3')
-    const carolUserId = await talentLayerID.walletOfOwner(carol.address)
-    const profileData = await talentLayerID.profiles(carolUserId)
-    expect(profileData.platformId).to.be.equal('1')
+      expect(talentLayerID.connect(carol).mintWithPoh('1', 'carol')).to.be.revertedWith(
+        'You need to use an address registered on Proof of Humanity',
+      )
+      await talentLayerID.connect(carol).mint('1', 'carol')
+      expect(await talentLayerID.walletOfOwner(alice.address)).to.be.equal('1')
+      expect(await talentLayerID.walletOfOwner(bob.address)).to.be.equal('2')
+      expect(await talentLayerID.walletOfOwner(carol.address)).to.be.equal('3')
+      const carolUserId = await talentLayerID.walletOfOwner(carol.address)
+      const profileData = await talentLayerID.profiles(carolUserId)
+      expect(profileData.platformId).to.be.equal('1')
+    })
+
+    it('Carol can activate POH on her talentLayerID', async function () {
+      expect(talentLayerID.connect(carol).mintWithPoh(1, 'carol')).to.be.revertedWith(
+        "You're address is not registerd for poh",
+      )
+      await mockProofOfHumanity.addSubmissionManually([carol.address])
+      await talentLayerID.connect(carol).activatePoh(3)
+      const profileData = await talentLayerID.profiles(3)
+
+      expect(await talentLayerID.isTokenPohRegistered(3)).to.be.equal(true)
+      expect(await profileData.pohAddress).to.be.equal(carol.address)
+    })
+
+    it('The deployer can update the mint fee', async function () {
+      await talentLayerID.connect(deployer).updateMintFee(mintFee)
+      const updatedMintFee = await talentLayerID.mintFee()
+
+      expect(updatedMintFee).to.be.equal(mintFee)
+    })
+
+    it('Eve can mint a talentLayerId by paying the mint fee', async function () {
+      const eveBalanceBefore = await eve.getBalance()
+      const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
+
+      // Mint fails if not enough ETH is sent
+      expect(talentLayerID.connect(eve).mint('1', 'eve')).to.be.revertedWith('Incorrect amount of ETH for mint fee')
+
+      // Mint is successful if the correct amount of ETH for mint fee is sent
+      await talentLayerID.connect(eve).mint('1', 'eve', { value: mintFee })
+      expect(await talentLayerID.walletOfOwner(eve.address)).to.be.equal('4')
+
+      // Eve balance is decreased by the mint fee (+ gas fees)
+      const eveBalanceAfter = await eve.getBalance()
+      expect(eveBalanceAfter).to.be.lte(eveBalanceBefore.sub(mintFee))
+
+      // TalentLayer id contract balance is increased by the mint fee
+      const contractBalanceAfter = await ethers.provider.getBalance(talentLayerID.address)
+      expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
+    })
+
+    it("The deployer can withdraw the contract's balance", async function () {
+      const deployerBalanceBefore = await deployer.getBalance()
+      const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
+
+      // Withdraw fails if the caller is not the owner
+      expect(talentLayerID.connect(alice).withdraw()).to.be.revertedWith('Ownable: caller is not the owner')
+
+      // Withdraw is successful if the caller is the owner
+      const tx = await talentLayerID.connect(deployer).withdraw()
+      const receipt = await tx.wait()
+      const gasUsed = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+
+      const deployerBalanceAfter = await deployer.getBalance()
+      const contractBalanceAfter = await ethers.provider.getBalance(talentLayerID.address)
+
+      // Deployer balance is increased by the contract balance (- gas fees)s
+      expect(deployerBalanceAfter).to.be.equal(deployerBalanceBefore.add(contractBalanceBefore).sub(gasUsed))
+
+      // Contract balance is 0
+      expect(contractBalanceAfter).to.be.equal(0)
+    })
   })
 
-  it('Carol can activate POH on her talentLayerID', async function() {
-    expect(talentLayerID.connect(carol).mintWithPoh(1, 'carol')).to.be.revertedWith(
-      "You're address is not registerd for poh",
-    )
-    await mockProofOfHumanity.addSubmissionManually([carol.address])
-    await talentLayerID.connect(carol).activatePoh(3)
-    const profileData = await talentLayerID.profiles(3)
-
-    expect(await talentLayerID.isTokenPohRegistered(3)).to.be.equal(true)
-    expect(await profileData.pohAddress).to.be.equal(carol.address)
-  })
-
-  it('Alice, the buyer, can initiate a new service with Bob, the seller', async function() {
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    await serviceRegistry.connect(alice).createServiceFromBuyer(1, bobTid, 'cid')
-    const serviceData = await serviceRegistry.services(1)
-
-    expect(serviceData.status.toString()).to.be.equal('0')
-    expect(serviceData.buyerId.toString()).to.be.equal('1')
-    expect(serviceData.initiatorId.toString()).to.be.equal('1')
-    expect(serviceData.sellerId.toString()).to.be.equal('2')
-    expect(serviceData.serviceDataUri).to.be.equal('cid')
-    expect(serviceData.platformId).to.be.equal(1)
-  })
-
-  it('Alice should be able to update the service data', async function() {
-    await serviceRegistry.connect(alice).updateServiceData(1, 'New-service-data-Uri')
-    const serviceData = await serviceRegistry.services(1)
-    expect(serviceData.serviceDataUri).to.be.equal('New-service-data-Uri')
-  })
-
-  it("Alice can't create a new service with a talentLayerId 0", async function() {
-    expect(serviceRegistry.connect(alice).createServiceFromBuyer(0, 'cid', 1)).to.be.revertedWith(
-      'Seller 0 is not a valid TalentLayerId',
-    )
-    expect(serviceRegistry.connect(alice).createServiceFromSeller(0, 'cid', 1)).to.be.revertedWith(
-      'Buyer 0 is not a valid TalentLayerId',
-    )
-  })
-
-  it("Alice can't create a new open service with wrong TalentLayer Platform ID", async function() {
-    expect(serviceRegistry.connect(alice).createOpenServiceFromBuyer(2, 'wrongTlPid')).to.be.revertedWith(
-      'Invalid platform ID',
-    )
-  })
-
-  it("Alice can't create a new service from buyer with right TalentLayer Platform ID but wrong TalentLayer Id", async function() {
-    expect(serviceRegistry.connect(alice).createServiceFromBuyer(1, 6, 'cid')).to.be.revertedWith(
-      'Your ID is not a valid token ID',
-    )
-  })
-
-  it("Bob, the seller, can confirm the service, Alice can't, Carol can't", async function() {
-    expect(serviceRegistry.connect(alice).confirmService(1)).to.be.revertedWith(
-      "Only the user who didn't initate the service can confirm it",
-    )
-    expect(serviceRegistry.connect(carol).confirmService(1)).to.be.revertedWith("You're not an actor of this service")
-    await serviceRegistry.connect(bob).confirmService(1)
-    const serviceData = await serviceRegistry.services(1)
-    expect(serviceData.status.toString()).to.be.equal('1')
-    expect(serviceRegistry.connect(bob).confirmService(1)).to.be.revertedWith('Service has already been confirmed')
-  })
-
-  it("Bob can't write a review yet", async function() {
-    expect(talentLayerReview.connect(bob).addReview(1, 'cidReview', 3, 1)).to.be.revertedWith(
-      'The service is not finished yet',
-    )
-  })
-
-  it("Carol can't write a review as she's not linked to this service", async function() {
-    expect(talentLayerReview.connect(carol).addReview(1, 'cidReview', 5, 1)).to.be.revertedWith(
-      "You're not an actor of this service",
-    )
-  })
-
-  it('Alice can say that the service is finished', async function() {
-    await serviceRegistry.connect(alice).finishService(1)
-    const serviceData = await serviceRegistry.services(1)
-    expect(serviceData.status.toString()).to.be.equal('2')
-  })
-
-  it('Alice and Bob can write a review now and we can get review data', async function() {
-    await talentLayerReview.connect(alice).addReview(1, 'cidReview1', 2, 1)
-    await talentLayerReview.connect(bob).addReview(1, 'cidReview2', 4, 1)
-
-    const reviewData1 = await talentLayerReview.getReview(0)
-    console.log('reviewData1', reviewData1.dataUri)
-    const reviewData2 = await talentLayerReview.getReview(1)
-    console.log('reviewData2', reviewData2.dataUri)
-
-    expect(reviewData1.dataUri).to.be.equal('cidReview1')
-    expect(reviewData2.dataUri).to.be.equal('cidReview2')
-
-    expect(await reviewData1.platformId).to.be.equal(1)
-  })
-
-  it("Alice and Bob can't write a review for the same Service", async function() {
-    expect(talentLayerReview.connect(alice).addReview(1, 'cidReview', 0)).to.be.revertedWith('ReviewAlreadyMinted()')
-    expect(talentLayerReview.connect(bob).addReview(1, 'cidReview', 3)).to.be.revertedWith('ReviewAlreadyMinted()')
-  })
-
-  it('Carol, a new buyer, can initiate a new service with Bob, the seller', async function() {
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    await serviceRegistry.connect(carol).createServiceFromBuyer(1, bobTid, 'cid2')
-    const serviceData = await serviceRegistry.services(2)
-
-    expect(serviceData.status.toString()).to.be.equal('0')
-    expect(serviceData.buyerId.toString()).to.be.equal('3')
-    expect(serviceData.initiatorId.toString()).to.be.equal('3')
-    expect(serviceData.sellerId.toString()).to.be.equal('2')
-    expect(serviceData.serviceDataUri).to.be.equal('cid2')
-  })
-
-  it("Bob can reject Carol new service as he's not agree with the service details", async function() {
-    await serviceRegistry.connect(bob).rejectService(2)
-    const serviceData = await serviceRegistry.services(2)
-    expect(serviceData.status.toString()).to.be.equal('3')
-    expect(serviceRegistry.connect(bob).confirmService(1)).to.be.revertedWith("You can't finish this service")
-  })
-
-  it('Bob can post another service with fixed service details, and Carol confirmed it', async function() {
-    const carolId = await talentLayerID.walletOfOwner(carol.address)
-    await serviceRegistry.connect(bob).createServiceFromSeller(1, carolId, 'cid3')
-    let serviceData = await serviceRegistry.services(3)
-
-    expect(serviceData.status.toString()).to.be.equal('0')
-    expect(serviceData.buyerId.toString()).to.be.equal('3')
-    expect(serviceData.initiatorId.toString()).to.be.equal('2')
-    expect(serviceData.sellerId.toString()).to.be.equal('2')
-    expect(serviceData.serviceDataUri).to.be.equal('cid3')
-    expect(serviceData.platformId).to.be.equal(1)
-
-    await serviceRegistry.connect(carol).confirmService(3)
-    serviceData = await serviceRegistry.services(3)
-
-    expect(serviceData.status.toString()).to.be.equal('1')
-  })
-
-  it("Dave, who doesn't have TalentLayerID, can't create a service", async function() {
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    expect(serviceRegistry.connect(dave).createServiceFromBuyer(1, bobTid, 'cid')).to.be.revertedWith(
-      'You sould have a TalentLayerId',
-    )
-  })
-
-  it('Alice the buyer can create an Open service', async function() {
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-    const serviceData = await serviceRegistry.services(4)
-
-    expect(serviceData.status.toString()).to.be.equal('4')
-    expect(serviceData.buyerId.toString()).to.be.equal('1')
-    expect(serviceData.initiatorId.toString()).to.be.equal('1')
-    expect(serviceData.sellerId.toString()).to.be.equal('0')
-    expect(serviceData.serviceDataUri).to.be.equal('cid')
-    expect(serviceData.platformId).to.be.equal(1)
-  })
-
-  it('Alice can assign an seller to a Open service', async function() {
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    await serviceRegistry.connect(alice).assignSellerToService(5, bobTid)
-    const serviceData = await serviceRegistry.services(5)
-
-    expect(serviceData.status.toString()).to.be.equal('0')
-    expect(serviceData.sellerId.toString()).to.be.equal(bobTid)
-  })
-
-  it('Bob can confirm the Open service', async function() {
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    await serviceRegistry.connect(alice).assignSellerToService(6, bobTid)
-    await serviceRegistry.connect(bob).confirmService(6)
-    const serviceData = await serviceRegistry.services(6)
-
-    expect(serviceData.status.toString()).to.be.equal('1')
-  })
-
-  it('Bob can reject an Open service', async function() {
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    const carolId = await talentLayerID.walletOfOwner(carol.address)
-    await serviceRegistry.connect(alice).assignSellerToService(7, bobTid)
-    await serviceRegistry.connect(bob).rejectService(7)
-    const serviceData = await serviceRegistry.services(7)
-
-    expect(serviceData.status.toString()).to.be.equal('3')
-
-    await serviceRegistry.connect(alice).assignSellerToService(7, carolId)
-    await serviceRegistry.connect(carol).confirmService(7)
-    const serviceDataNewAssignement = await serviceRegistry.services(7)
-
-    expect(serviceDataNewAssignement.status.toString()).to.be.equal('1')
-  })
-
-  it('Bob can create a proposal for an Open service', async function() {
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-
-    // Proposal data check before the proposal
-    const proposalDataBefore = await serviceRegistry.getProposal(8, bobTid)
-    expect(proposalDataBefore.sellerId.toString()).to.be.equal('0')
-
-    await serviceRegistry.connect(bob).createProposal(8, rateToken, 1, 'cid')
-
-    const serviceData = await serviceRegistry.services(8)
-    const proposalDataAfter = await serviceRegistry.getProposal(8, bobTid)
-
-    // Service data check
-    expect(serviceData.status.toString()).to.be.equal('4')
-    expect(serviceData.buyerId.toString()).to.be.equal('1')
-
-    // Proposal data check after the proposal
-
-    expect(proposalDataAfter.rateToken).to.be.equal(rateToken)
-    expect(proposalDataAfter.rateAmount.toString()).to.be.equal('1')
-    expect(proposalDataAfter.proposalDataUri).to.be.equal('cid')
-    expect(proposalDataAfter.sellerId.toString()).to.be.equal('2')
-    expect(proposalDataAfter.status.toString()).to.be.equal('0')
-  })
-
-  it('Bob can update a proposal ', async function() {
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-    await serviceRegistry.connect(bob).createProposal(9, rateToken, 1, 'cid')
-
-    const proposalDataBefore = await serviceRegistry.getProposal(9, bobTid)
-    expect(proposalDataBefore.rateAmount.toString()).to.be.equal('1')
-
-    await serviceRegistry.connect(bob).updateProposal(9, rateToken, 2, 'cid2')
-
-    const proposalDataAfter = await serviceRegistry.getProposal(9, bobTid)
-    expect(proposalDataAfter.rateAmount.toString()).to.be.equal('2')
-    expect(proposalDataAfter.proposalDataUri).to.be.equal('cid2')
-  })
-
-  it('Alice can validate a proposal', async function() {
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-    await serviceRegistry.connect(bob).createProposal(10, rateToken, 1, 'cid')
-
-    const proposalDataBefore = await serviceRegistry.getProposal(10, bobTid)
-    expect(proposalDataBefore.status.toString()).to.be.equal('0')
-
-    await serviceRegistry.connect(alice).validateProposal(10, bobTid)
-
-    const proposalDataAfter = await serviceRegistry.getProposal(10, bobTid)
-    expect(proposalDataAfter.status.toString()).to.be.equal('1')
-  })
-
-  it('Alice can delete a proposal ', async function() {
-    const bobTid = await talentLayerID.walletOfOwner(bob.address)
-    const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
-    await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-    await serviceRegistry.connect(bob).createProposal(11, rateToken, 1, 'cid')
-
-    await serviceRegistry.connect(alice).rejectProposal(11, bobTid)
-
-    const proposalDataAfter = await serviceRegistry.getProposal(11, bobTid)
-    expect(proposalDataAfter.status.toString()).to.be.equal('2')
-  })
-
-  it('The deployer can update the mint fee', async function() {
-    await talentLayerID.connect(deployer).updateMintFee(mintFee)
-    const updatedMintFee = await talentLayerID.mintFee()
-
-    expect(updatedMintFee).to.be.equal(mintFee)
-  })
-
-  it('Eve can mint a talentLayerId by paying the mint fee', async function() {
-    const eveBalanceBefore = await eve.getBalance()
-    const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
-
-    // Mint fails if not enough ETH is sent
-    expect(talentLayerID.connect(eve).mint('1', 'eve')).to.be.revertedWith('Incorrect amount of ETH for mint fee')
-
-    // Mint is successful if the correct amount of ETH for mint fee is sent
-    await talentLayerID.connect(eve).mint('1', 'eve', { value: mintFee })
-    expect(await talentLayerID.walletOfOwner(eve.address)).to.be.equal('4')
-
-    // Eve balance is decreased by the mint fee (+ gas fees)
-    const eveBalanceAfter = await eve.getBalance()
-    expect(eveBalanceAfter).to.be.lte(eveBalanceBefore.sub(mintFee))
-
-    // TalentLayer id contract balance is increased by the mint fee
-    const contractBalanceAfter = await ethers.provider.getBalance(talentLayerID.address)
-    expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
-  })
-
-  it("The deployer can withdraw the contract's balance", async function() {
-    const deployerBalanceBefore = await deployer.getBalance()
-    const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
-
-    // Withdraw fails if the caller is not the owner
-    expect(talentLayerID.connect(alice).withdraw()).to.be.revertedWith('Ownable: caller is not the owner')
-
-    // Withdraw is successful if the caller is the owner
-    const tx = await talentLayerID.connect(deployer).withdraw()
-    const receipt = await tx.wait()
-    const gasUsed = receipt.gasUsed.mul(receipt.effectiveGasPrice)
-
-    const deployerBalanceAfter = await deployer.getBalance()
-    const contractBalanceAfter = await ethers.provider.getBalance(talentLayerID.address)
-
-    // Deployer balance is increased by the contract balance (- gas fees)s
-    expect(deployerBalanceAfter).to.be.equal(deployerBalanceBefore.add(contractBalanceBefore).sub(gasUsed))
-
-    // Contract balance is 0
-    expect(contractBalanceAfter).to.be.equal(0)
-  })
-
-  describe('SimpleERC20 contract.', function() {
-    describe('Deployment', function() {
+  describe('SimpleERC20 contract contract test', function () {
+    describe('Deployment', function () {
       // it("Should be accessible", async function () {
       //   await loadFixture(deployTokenFixture);
       //   expect(await token.ping()).to.equal(1);
       // });
 
-      it('Should set the right deployer', async function() {
+      it('Should set the right deployer', async function () {
         expect(await token.owner()).to.equal(deployer.address)
       })
 
-      it('Should assign the total supply of tokens to the deployer', async function() {
+      it('Should assign the total supply of tokens to the deployer', async function () {
         // await loadFixture(deployTokenFixture);
         const deployerBalance = await token.balanceOf(deployer.address)
         const totalSupply = await token.totalSupply()
         expect(totalSupply).to.equal(deployerBalance)
       })
 
-      it('Should transfer 10000000 tokens to alice', async function() {
+      it('Should transfer 10000000 tokens to alice', async function () {
         // await loadFixture(deployTokenFixture);
         expect(token.transfer(alice.address, 10000000)).to.changeTokenBalances(token, [deployer, alice], [-1000, 1000])
       })
     })
 
-    describe('Token transactions.', function() {
-      it('Should transfer tokens between accounts', async function() {
+    describe('Token transactions.', function () {
+      it('Should transfer tokens between accounts', async function () {
         // await loadFixture(deployTokenFixture);
 
         // Transfer 50 tokens from deployer to alice
@@ -588,7 +339,7 @@ describe('TalentLayer', function() {
         expect(token.connect(alice).transfer(bob.address, 50)).to.changeTokenBalances(token, [alice, bob], [-50, 50])
       })
 
-      it('Should emit Transfer events.', async function() {
+      it('Should emit Transfer events.', async function () {
         // await loadFixture(deployTokenFixture);
 
         // Transfer 50 tokens from deployer to alice
@@ -602,7 +353,7 @@ describe('TalentLayer', function() {
           .withArgs(alice.address, bob.address, 50)
       })
 
-      it("Should revert when sender doesn't have enough tokens.", async function() {
+      it("Should revert when sender doesn't have enough tokens.", async function () {
         // await loadFixture(deployTokenFixture);
 
         const initialdeployerBalance = await token.balanceOf(deployer.address)
@@ -618,21 +369,141 @@ describe('TalentLayer', function() {
     })
   })
 
-  describe('Escrow Contract.', function() {
-    describe('Successful use of Escrow for a service using an ERC20 token.', function() {
+  describe('Service Registry & Proposal contract test', function () {
+    it("Dave, who doesn't have TalentLayerID, can't create a service", async function () {
+      expect(serviceRegistry.connect(dave).createOpenServiceFromBuyer(1, 'haveNotTlid')).to.be.revertedWith(
+        'You sould have a TalentLayerId',
+      )
+    })
+
+    it("Alice can't create a new service with a talentLayerId 0", async function () {
+      expect(serviceRegistry.connect(alice).createOpenServiceFromBuyer(0, 'cid0')).to.be.revertedWith(
+        'Seller 0 is not a valid TalentLayerId',
+      )
+      expect(serviceRegistry.connect(alice).createOpenServiceFromBuyer(0, 'cid0')).to.be.revertedWith(
+        'Buyer 0 is not a valid TalentLayerId',
+      )
+    })
+
+    it('Alice the buyer can create a few Open service', async function () {
+      // Alice will create 4 Open services fo the whole unit test process
+      await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'CID1')
+      const serviceData = await serviceRegistry.services(1)
+
+      // service 2
+      await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'CID2')
+      const serviceData2 = await serviceRegistry.services(2)
+
+      // service 3
+      await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'CID3')
+      const serviceData3 = await serviceRegistry.services(3)
+
+      // service 4
+      await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'CID4')
+      const serviceData4 = await serviceRegistry.services(4)
+
+      expect(serviceData.status.toString()).to.be.equal('4')
+      expect(serviceData.buyerId.toString()).to.be.equal('1')
+      expect(serviceData.initiatorId.toString()).to.be.equal('1')
+      expect(serviceData.serviceDataUri).to.be.equal('CID1')
+      expect(serviceData.platformId).to.be.equal(1)
+    })
+
+    it("Alice can't create a new open service with wrong TalentLayer Platform ID", async function () {
+      expect(serviceRegistry.connect(alice).createOpenServiceFromBuyer(5, 'wrongTlPid')).to.be.revertedWith(
+        'Invalid platform ID',
+      )
+    })
+
+    it('Alice can update her service data', async function () {
+      await serviceRegistry.connect(alice).updateServiceData(1, 'aliceUpdateHerFirstService')
+      const serviceData = await serviceRegistry.services(1)
+      expect(serviceData.serviceDataUri).to.be.equal('aliceUpdateHerFirstService')
+    })
+
+    it('Bob can create his first proposal for an Open service n°1 from Alice', async function () {
+      // Proposal on the Open service n 1
+      const bobTid = await talentLayerID.walletOfOwner(bob.address)
+      const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
+
+      // Proposal data check before the proposal
+      const proposalDataBefore = await serviceRegistry.getProposal(1, bobTid)
+      expect(proposalDataBefore.sellerId.toString()).to.be.equal('0')
+
+      await serviceRegistry.connect(bob).createProposal(1, rateToken, 1, 'proposal1FromBobToAlice1Service')
+
+      const serviceData = await serviceRegistry.services(1)
+      const proposalDataAfter = await serviceRegistry.getProposal(1, bobTid)
+
+      // Service data check
+      expect(serviceData.status.toString()).to.be.equal('4')
+      expect(serviceData.buyerId.toString()).to.be.equal('1')
+
+      // Proposal data check after the proposal
+
+      expect(proposalDataAfter.rateToken).to.be.equal(rateToken)
+      expect(proposalDataAfter.rateAmount.toString()).to.be.equal('1')
+      expect(proposalDataAfter.proposalDataUri).to.be.equal('proposal1FromBobToAlice1Service')
+      expect(proposalDataAfter.sellerId.toString()).to.be.equal('2')
+      expect(proposalDataAfter.status.toString()).to.be.equal('0')
+    })
+
+    it('Carol can create her first proposal (will be rejected by Alice) ', async function () {
+      const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
+      await serviceRegistry.connect(carol).createProposal(1, rateToken, 2, 'proposal1FromCarolToAlice1Service')
+      const serviceData = await serviceRegistry.services(1)
+      // get proposal info
+      const carolTid = await talentLayerID.walletOfOwner(carol.address)
+      const proposalData = await serviceRegistry.getProposal(1, carolTid)
+    })
+
+    it('Bob can update his first proposal ', async function () {
+      const bobTid = await talentLayerID.walletOfOwner(bob.address)
+      const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
+
+      const proposalDataBefore = await serviceRegistry.getProposal(1, bobTid)
+      expect(proposalDataBefore.rateAmount.toString()).to.be.equal('1')
+
+      await serviceRegistry.connect(bob).updateProposal(1, rateToken, 2, 'updateProposal1FromBobToAlice1Service')
+
+      const proposalDataAfter = await serviceRegistry.getProposal(1, bobTid)
+      expect(proposalDataAfter.rateAmount.toString()).to.be.equal('2')
+      expect(proposalDataAfter.proposalDataUri).to.be.equal('updateProposal1FromBobToAlice1Service')
+    })
+
+    it('Alice can validate Bob proposal', async function () {
+      const bobTid = await talentLayerID.walletOfOwner(bob.address)
+      const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
+
+      const proposalDataBefore = await serviceRegistry.getProposal(1, bobTid)
+      expect(proposalDataBefore.status.toString()).to.be.equal('0')
+
+      await serviceRegistry.connect(alice).validateProposal(1, bobTid)
+
+      const proposalDataAfter = await serviceRegistry.getProposal(1, bobTid)
+      expect(proposalDataAfter.status.toString()).to.be.equal('1')
+    })
+
+    it('Alice can reject Carol proposal ', async function () {
+      const carolTid = await talentLayerID.walletOfOwner(carol.address)
+      await serviceRegistry.connect(alice).rejectProposal(1, carolTid)
+
+      const proposalDataAfter = await serviceRegistry.getProposal(1, carolTid)
+      expect(proposalDataAfter.status.toString()).to.be.equal('2')
+    })
+  })
+
+  describe('Escrow Contract test.', function () {
+    describe('Successful use of Escrow for a service using an ERC20 token.', function () {
       const amountBob = 1000000
       const amountCarol = 2000
-      const serviceId = 12
+      const serviceId = 2
       const transactionId = 0
       let proposalIdBob = 0 //Will be set later
       let proposalIdCarol = 0 //Will be set later
       let totalAmount = 0 //Will be set later
 
-      it('Alice can create a service.', async function() {
-        await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-      })
-
-      it('Alice can NOT deposit tokens to escrow yet.', async function() {
+      it('Alice can NOT deposit tokens to escrow yet.', async function () {
         await token.connect(alice).approve(talentLayerMultipleArbitrableTransaction.address, amountBob)
         expect(
           talentLayerMultipleArbitrableTransaction
@@ -641,17 +512,21 @@ describe('TalentLayer', function() {
         ).to.be.reverted
       })
 
-      it('Bob can register a proposal.', async function() {
+      it('Bob can make a second proposal on the Alice service n°2', async function () {
         proposalIdBob = await talentLayerID.walletOfOwner(bob.address)
-        await serviceRegistry.connect(bob).createProposal(serviceId, token.address, amountBob, 'cid')
+        await serviceRegistry
+          .connect(bob)
+          .createProposal(serviceId, token.address, amountBob, 'proposal2FromBobToAlice2Service')
       })
 
-      it('Carol can register a proposal.', async function() {
+      it('Carol can make her second proposal on the Alice service n°2', async function () {
         proposalIdCarol = await talentLayerID.walletOfOwner(carol.address)
-        await serviceRegistry.connect(carol).createProposal(serviceId, token.address, amountCarol, 'cid')
+        await serviceRegistry
+          .connect(carol)
+          .createProposal(serviceId, token.address, amountCarol, 'proposal2FromCarolToAlice2Service')
       })
 
-      it('Alice cannot update originPlatformFee, protocolFee or protocolWallet', async function() {
+      it('Alice cannot update originPlatformFee, protocolFee or protocolWallet', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(alice).updateProtocolFee(4000),
         ).to.be.revertedWith('Ownable: caller is not the owner')
@@ -663,7 +538,7 @@ describe('TalentLayer', function() {
         ).to.be.revertedWith('Ownable: caller is not the owner')
       })
 
-      it('The Deployer can update originPlatformFee, protocolFee and protocolWallet', async function() {
+      it('The Deployer can update originPlatformFee, protocolFee and protocolWallet', async function () {
         let protocolWallet = await talentLayerMultipleArbitrableTransaction.connect(deployer).getProtocolWallet()
         expect(protocolWallet).to.equal(deployer.address)
         await talentLayerMultipleArbitrableTransaction.connect(deployer).updateProtocolWallet(dave.address)
@@ -678,7 +553,7 @@ describe('TalentLayer', function() {
         expect(originPlatformFee).to.equal(1400)
       })
 
-      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function() {
+      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function () {
         const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
         await talentLayerPlatformID.connect(alice).updatePlatformfee(aliceUserId, 1100)
         const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
@@ -704,19 +579,19 @@ describe('TalentLayer', function() {
           .withArgs(serviceId, proposalIdBob, transactionId)
       })
 
-      it('The deposit should also validate the proposal.', async function() {
+      it('The deposit should also validate the proposal.', async function () {
         const proposal = await serviceRegistry.getProposal(serviceId, proposalIdBob)
         await expect(proposal.status.toString()).to.be.equal('1')
       })
 
-      it('The deposit should also update the service with transactionId, proposalId, and status.', async function() {
+      it('The deposit should also update the service with transactionId, proposalId, and status.', async function () {
         const service = await serviceRegistry.getService(serviceId)
         await expect(service.status.toString()).to.be.equal('1')
         await expect(service.transactionId.toString()).to.be.equal('0')
         await expect(service.sellerId.toString()).to.be.equal(proposalIdBob)
       })
 
-      it("Alice can NOT deposit funds for Carol's proposal.", async function() {
+      it("Alice can NOT deposit funds for Carol's proposal.", async function () {
         await token.connect(alice).approve(talentLayerMultipleArbitrableTransaction.address, amountCarol)
         await expect(
           talentLayerMultipleArbitrableTransaction
@@ -725,13 +600,13 @@ describe('TalentLayer', function() {
         ).to.be.reverted
       })
 
-      it('Carol should not be allowed to release escrow the service.', async function() {
+      it('Carol should not be allowed to release escrow the service.', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(carol).release(transactionId, 10),
         ).to.be.revertedWith('Access denied.')
       })
 
-      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function() {
+      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerMultipleArbitrableTransaction
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -760,7 +635,7 @@ describe('TalentLayer', function() {
         await expect(deployerBalance.toString()).to.be.equal((((amountBob / 2) * protocolFee) / 10000).toString())
       })
 
-      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function() {
+      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerMultipleArbitrableTransaction
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -790,19 +665,19 @@ describe('TalentLayer', function() {
         await expect(deployerBalance.toString()).to.be.equal(((((3 * amountBob) / 4) * protocolFee) / 10000).toString())
       })
 
-      it('Carol can NOT reimburse alice.', async function() {
+      it('Carol can NOT reimburse alice.', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(carol).reimburse(transactionId, totalAmount / 4),
         ).to.revertedWith('Access denied.')
       })
 
-      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function() {
+      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(bob).reimburse(transactionId, totalAmount),
         ).to.revertedWith('Insufficient funds.')
       })
 
-      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function() {
+      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function () {
         const transaction = await talentLayerMultipleArbitrableTransaction
           .connect(bob)
           .reimburse(transactionId, amountBob / 4)
@@ -820,13 +695,13 @@ describe('TalentLayer', function() {
           .withArgs(serviceId)
       })
 
-      it('Alice can not release escrow because there is none left. ', async function() {
+      it('Alice can not release escrow because there is none left. ', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(alice).release(transactionId, 1),
         ).to.be.revertedWith('Insufficient funds.')
       })
 
-      it('Alice can claim her token balance.', async function() {
+      it('Alice can claim her token balance.', async function () {
         const platformBalance = await talentLayerMultipleArbitrableTransaction
           .connect(alice)
           .getClaimableFeeBalance(token.address)
@@ -840,7 +715,7 @@ describe('TalentLayer', function() {
         )
       })
 
-      it('The protocol owner can claim his token balance.', async function() {
+      it('The protocol owner can claim his token balance.', async function () {
         let protocolOwnerBalance = await talentLayerMultipleArbitrableTransaction
           .connect(deployer)
           .getClaimableFeeBalance(token.address)
@@ -853,22 +728,17 @@ describe('TalentLayer', function() {
         )
       })
     })
-
-    describe('Successful use of Escrow for a service using ETH.', function() {
+    describe('Successful use of Escrow for a service using ETH.', function () {
       const amountBob = 1000000
       const amountCarol = 200
-      const serviceId = 13
+      const serviceId = 3
       const transactionId = 1
       let proposalIdBob = 0 //Will be set later
       let proposalIdCarol = 0 //Will be set later
       let totalAmount = 0 //Will be set later
       const ethAddress = '0x0000000000000000000000000000000000000000'
 
-      it('Alice can create a service.', async function() {
-        await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'cid')
-      })
-
-      it('Alice can NOT deposit eth to escrow yet.', async function() {
+      it('Alice can NOT deposit eth to escrow yet.', async function () {
         const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
         await talentLayerPlatformID.connect(alice).updatePlatformfee(aliceUserId, 1100)
         const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
@@ -886,17 +756,21 @@ describe('TalentLayer', function() {
         ).to.be.reverted
       })
 
-      it('Bob can register a proposal.', async function() {
+      it('Bob can register a proposal.', async function () {
         proposalIdBob = await talentLayerID.walletOfOwner(bob.address)
-        await serviceRegistry.connect(bob).createProposal(serviceId, ethAddress, amountBob, 'cid')
+        await serviceRegistry
+          .connect(bob)
+          .createProposal(serviceId, ethAddress, amountBob, 'proposal3FromBobToAlice3Service')
       })
 
-      it('Carol can register a proposal.', async function() {
+      it('Carol can register a proposal.', async function () {
         proposalIdCarol = await talentLayerID.walletOfOwner(carol.address)
-        await serviceRegistry.connect(carol).createProposal(serviceId, ethAddress, amountCarol, 'cid')
+        await serviceRegistry
+          .connect(carol)
+          .createProposal(serviceId, ethAddress, amountCarol, 'proposal3FromCarolToAlice3Service')
       })
 
-      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function() {
+      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function () {
         const transaction = await talentLayerMultipleArbitrableTransaction
           .connect(alice)
           .createETHTransaction(3600 * 24 * 7, '_metaEvidence', serviceId, proposalIdBob, { value: totalAmount })
@@ -910,19 +784,19 @@ describe('TalentLayer', function() {
           .withArgs(serviceId, proposalIdBob, transactionId)
       })
 
-      it('The deposit should also validate the proposal.', async function() {
+      it('The deposit should also validate the proposal.', async function () {
         const proposal = await serviceRegistry.getProposal(serviceId, proposalIdBob)
         await expect(proposal.status.toString()).to.be.equal('1')
       })
 
-      it('The deposit should also update the service with transactionId, proposalId, and status.', async function() {
+      it('The deposit should also update the service with transactionId, proposalId, and status.', async function () {
         const service = await serviceRegistry.getService(serviceId)
         await expect(service.status.toString()).to.be.equal('1')
         await expect(service.transactionId).to.be.equal(transactionId)
         await expect(service.sellerId).to.be.equal(proposalIdBob)
       })
 
-      it("Alice can NOT deposit funds for Carol's proposal, and NO event should emit.", async function() {
+      it("Alice can NOT deposit funds for Carol's proposal, and NO event should emit.", async function () {
         await token.connect(alice).approve(talentLayerMultipleArbitrableTransaction.address, amountCarol)
         expect(
           talentLayerMultipleArbitrableTransaction
@@ -931,13 +805,13 @@ describe('TalentLayer', function() {
         ).to.be.reverted
       })
 
-      it('Carol should not be allowed to release escrow the service.', async function() {
+      it('Carol should not be allowed to release escrow the service.', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(carol).release(transactionId, 10),
         ).to.be.revertedWith('Access denied.')
       })
 
-      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function() {
+      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerMultipleArbitrableTransaction
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -966,7 +840,7 @@ describe('TalentLayer', function() {
         await expect(deployerBalance.toString()).to.be.equal((((amountBob / 2) * protocolFee) / 10000).toString())
       })
 
-      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function() {
+      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerMultipleArbitrableTransaction
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -994,19 +868,19 @@ describe('TalentLayer', function() {
         await expect(deployerBalance.toString()).to.be.equal(((((3 * amountBob) / 4) * protocolFee) / 10000).toString())
       })
 
-      it('Carol can NOT reimburse alice.', async function() {
+      it('Carol can NOT reimburse alice.', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(carol).reimburse(transactionId, totalAmount / 4),
         ).to.revertedWith('Access denied.')
       })
 
-      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function() {
+      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(bob).reimburse(transactionId, totalAmount),
         ).to.revertedWith('Insufficient funds.')
       })
 
-      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function() {
+      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function () {
         const transaction = await talentLayerMultipleArbitrableTransaction
           .connect(bob)
           .reimburse(transactionId, amountBob / 4)
@@ -1023,13 +897,13 @@ describe('TalentLayer', function() {
           .withArgs(serviceId)
       })
 
-      it('Alice can not release escrow because there is none left.', async function() {
+      it('Alice can not release escrow because there is none left.', async function () {
         await expect(
           talentLayerMultipleArbitrableTransaction.connect(alice).release(transactionId, 10),
         ).to.be.revertedWith('Insufficient funds.')
       })
 
-      it('Alice can claim her ETH balance.', async function() {
+      it('Alice can claim her ETH balance.', async function () {
         const platformEthBalance = await talentLayerMultipleArbitrableTransaction
           .connect(alice)
           .getClaimableFeeBalance(ethAddress)
@@ -1040,7 +914,7 @@ describe('TalentLayer', function() {
         )
       })
 
-      it('The Protocol owner can claim his ETH balance.', async function() {
+      it('The Protocol owner can claim his ETH balance.', async function () {
         const protocolEthBalance = await talentLayerMultipleArbitrableTransaction
           .connect(deployer)
           .getClaimableFeeBalance(ethAddress)
@@ -1050,6 +924,38 @@ describe('TalentLayer', function() {
           [-protocolEthBalance, protocolEthBalance],
         )
       })
+    })
+  })
+
+  describe('Talent Layer Review contract test', function () {
+    it("Bob can't write a review yet", async function () {
+      expect(talentLayerReview.connect(bob).addReview(1, 'cidReview', 3, 1)).to.be.revertedWith(
+        'The service is not finished yet',
+      )
+    })
+
+    it("Carol can't write a review as she's not linked to this service", async function () {
+      expect(talentLayerReview.connect(carol).addReview(1, 'cidReview', 5, 1)).to.be.revertedWith(
+        "You're not an actor of this service",
+      )
+    })
+
+    it("Alice and Bob can't write a review for the same Service", async function () {
+      expect(talentLayerReview.connect(alice).addReview(1, 'cidReview', 0)).to.be.revertedWith('ReviewAlreadyMinted()')
+      expect(talentLayerReview.connect(bob).addReview(1, 'cidReview', 3)).to.be.revertedWith('ReviewAlreadyMinted()')
+    })
+
+    it('Alice and Bob can write a review now and we can get review data', async function () {
+      await talentLayerReview.connect(alice).addReview(2, 'cidReview1', 2, 1)
+      await talentLayerReview.connect(bob).addReview(2, 'cidReview2', 4, 1)
+
+      const reviewData1 = await talentLayerReview.getReview(0)
+      const reviewData2 = await talentLayerReview.getReview(1)
+
+      expect(reviewData1.dataUri).to.be.equal('cidReview1')
+      expect(reviewData2.dataUri).to.be.equal('cidReview2')
+
+      expect(await reviewData1.platformId).to.be.equal(1)
     })
   })
 })


### PR DESCRIPTION
Delete function in ServiceRegistry contract :
- createServiceFromBuyer / createServiceFromSeller / confirmService / rejectService / finishService /assignSellerToService

In TalentLayer test
- Update the test after the fct deletion
- Re organize test by contract
-  Refactoring unit test