### PR TITLE
201 - Protocol tokens allow list

### DIFF
--- a/contracts/tests/ServiceRegistryV2.sol
+++ b/contracts/tests/ServiceRegistryV2.sol
@@ -59,7 +59,7 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
     /// @param status the current status of a service
     /// @param sellerId the talentLayerId of the seller
     /// @param rateToken the token choose for the payment
-    /// @param rateAmount the amount of token choosed
+    /// @param rateAmount the amount of token chosen
     /// @param proposalDataUri token Id to IPFS URI mapping
     struct Proposal {
         ProposalStatus status;
@@ -136,6 +136,15 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
     /// @param sellerId the talentLayerId of the seller
     event ProposalRejected(uint256 serviceId, uint256 sellerId);
 
+    /**
+     * @notice Emitted when the contract owner adds or removes a token from the allowed payment tokens list
+     * @param _tokenAddress The address of the payment token
+     * @param _status Whether the token is allowed or not
+     */
+    event AllowedTokenListUpdated(address _tokenAddress, bool _status);
+
+    // =========================== Mappings & Variables ==============================
+
     /// @notice incremental service Id
     uint256 public nextServiceId;
 
@@ -150,6 +159,9 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
 
     /// @notice proposals mappings index by service ID and seller TID
     mapping(uint256 => mapping(uint256 => Proposal)) public proposals;
+
+    /// @notice Allowed payment tokens addresses
+    mapping(address => bool) public allowedTokens;
 
     // @notice
     bytes32 public constant ESCROW_ROLE = keccak256("ESCROW_ROLE");
@@ -179,7 +191,7 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
     // =========================== View functions ==============================
 
     /**
-     * @notice Return the whole service data information
+     * @notice Returns the whole service data information
      * @param _serviceId Service identifier
      */
     function getService(uint256 _serviceId) external view returns (Service memory) {
@@ -187,8 +199,21 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
         return services[_serviceId];
     }
 
+    /**
+     * @notice Returns the specific proposal for the attached service
+     * @param _serviceId Service identifier
+     * @param _proposalId Proposal identifier
+     */
     function getProposal(uint256 _serviceId, uint256 _proposalId) external view returns (Proposal memory) {
         return proposals[_serviceId][_proposalId];
+    }
+
+    /**
+     * @notice Indicates whether the token in parameter is allowed for payment
+     * @param _tokenAddress Token address
+     */
+    function isTokenAllowed(address _tokenAddress) external view returns (bool) {
+        return allowedTokens[_tokenAddress];
     }
 
     // =========================== User functions ==============================
@@ -219,6 +244,7 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
     ) public {
         uint256 senderId = tlId.walletOfOwner(msg.sender);
         require(senderId > 0, "You should have a TalentLayerId");
+        require(allowedTokens[_rateToken], "This token is not allowed");
 
         Service storage service = services[_serviceId];
         require(service.status == Status.Opened, "Service is not opened");
@@ -257,6 +283,7 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
     ) public {
         uint256 senderId = tlId.walletOfOwner(msg.sender);
         require(senderId > 0, "You should have a TalentLayerId");
+        require(allowedTokens[_rateToken], "This token is not allowed");
 
         Service storage service = services[_serviceId];
         Proposal storage proposal = proposals[_serviceId][senderId];
@@ -333,6 +360,19 @@ contract ServiceRegistryV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
         service.sellerId = proposal.sellerId;
         service.transactionId = _transactionId;
         proposal.status = ProposalStatus.Validated;
+    }
+
+    /**
+     * @notice Allows the contract owner to add or remove a token from the allowed payment tokens list
+     * @param _tokenAddress The address of the payment token
+     * @param _status Whether the token is allowed or not
+     * @dev Only the contract owner can call this function
+     */
+    function updateAllowedTokenList(address _tokenAddress, bool _status) public onlyOwner {
+        require(allowedTokens[_tokenAddress] != _status, "Status should be different");
+        allowedTokens[_tokenAddress] = _status;
+
+        emit AllowedTokenListUpdated(_tokenAddress, _status);
     }
 
     /**

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,7 +3,7 @@ import type { NetworkUserConfig } from 'hardhat/types'
 import { config as dotenvConfig } from 'dotenv'
 import { resolve } from 'path'
 import '@nomicfoundation/hardhat-toolbox'
-import "@openzeppelin/hardhat-upgrades";
+import '@openzeppelin/hardhat-upgrades'
 import 'hardhat-contract-sizer'
 import './scripts/tasks/deploy/01-full'
 import './scripts/tasks/deploy/02-service-registry-v2'
@@ -13,6 +13,7 @@ import './scripts/tasks/protocol/mintTalentLayerId'
 import './scripts/tasks/protocol/addArbitrator'
 import './scripts/tasks/protocol/removeArbitrator'
 import './scripts/tasks/protocol/updateMinArbitrationFeeTimeout'
+import './scripts/tasks/protocol/addOrRemoveTokenAddressToWhitelist'
 import { Network } from './scripts/utils/config'
 
 dotenvConfig({ path: resolve(__dirname, './.env') })
@@ -82,7 +83,7 @@ const config: HardhatUserConfig = {
   gasReporter: {
     currency: 'USD',
     coinmarketcap: process.env.COINMARKETCAP_API_KEY,
-    enabled: process.env.REPORT_GAS ? true : false,
+    enabled: !!process.env.REPORT_GAS,
     showTimeSpent: true,
     excludeContracts: [],
     src: './contracts',

--- a/scripts/tasks/protocol/addOrRemoveTokenAddressToWhitelist.ts
+++ b/scripts/tasks/protocol/addOrRemoveTokenAddressToWhitelist.ts
@@ -1,0 +1,38 @@
+import { task } from 'hardhat/config'
+import { Network } from '../../utils/config'
+import { ConfigProperty, get } from '../../../configManager'
+
+/**
+ * @notice This task is used to add a token address to the whitelist
+ * @param {string} tokenAddress - The address of the token to be added to the whitelist
+ * @param {string} action - Input "add" to add the token address & "remove" to remove the token address from the whitelist
+ * @dev Example of script use: "npx hardhat add-token-address-to-whitelist --address 0x5FbDB2315678afecb367f032d93F642f64180aa3 --action add --network goerli"
+ * @dev Only contract owner can execute this task
+ */
+task('add-token-address-to-whitelist', 'Adds a token address to the whitelist')
+  .addParam('address', "The token's address")
+  .addParam('action', 'The action to perform: "add" or "remove"')
+  .setAction(async (taskArgs, { ethers, network }) => {
+    const { address, action } = taskArgs
+    const [deployer] = await ethers.getSigners()
+
+    console.log('network', network.name)
+
+    const serviceRegistry = await ethers.getContractAt(
+      'ServiceRegistry',
+      get(network.name as any as Network, ConfigProperty.ServiceRegistry),
+      deployer,
+    )
+
+    const tx = await serviceRegistry.updateAllowedTokenList(address, action === Actions.ADD)
+    await tx.wait()
+    const isTokenRegistered = await serviceRegistry.isTokenAllowed(address)
+    console.log(
+      `Updates token whitelist: ${address} was ${isTokenRegistered ? 'added to ' : 'removed from '}the whitelist`,
+    )
+  })
+
+export enum Actions {
+  ADD = 'add',
+  REMOVE = 'remove',
+}

--- a/test/batch/TalentLayer.ts
+++ b/test/batch/TalentLayer.ts
@@ -4,7 +4,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { BigNumber, Contract } from 'ethers'
 import { deploy } from '../utils/deploy'
 
-describe('TalentLayer protocol global testing', function() {
+describe('TalentLayer protocol global testing', function () {
   // we dedine the types of the variables we will use
   let deployer: SignerWithAddress,
     alice: SignerWithAddress,
@@ -27,7 +27,9 @@ describe('TalentLayer protocol global testing', function() {
     platformId: string,
     mintFee: number
 
-  before(async function() {
+  const nonListedRateToken = '0x6b175474e89094c44da98b954eedeac495271d0f'
+
+  before(async function () {
     // Get the Signers
     ;[deployer, alice, bob, carol, dave, eve, frank, grace, heidi] = await ethers.getSigners()
     ;[
@@ -53,20 +55,34 @@ describe('TalentLayer protocol global testing', function() {
     platformName = 'HireVibes'
     await talentLayerPlatformID.connect(deployer).mintForAddress(platformName, alice.address)
     mintFee = 100
+
+    const allowedTokenList = [
+      '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10',
+      '0x0000000000000000000000000000000000000000',
+      '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
+      '0x73967c6a0904aa032c103b4104747e88c566b1a2',
+      '0xd80d331d3b6dca0a20f4af2edc9c9645cd1f10c8',
+      token.address,
+    ]
+
+    // Deployer whitelists a list of authorized tokens
+    for (const tokenAddress of allowedTokenList) {
+      await serviceRegistry.connect(deployer).updateAllowedTokenList(tokenAddress, true)
+    }
   })
 
-  describe('Platform Id contract test', async function() {
-    it('Alice successfully minted a PlatformId Id', async function() {
+  describe('Platform Id contract test', async function () {
+    it('Alice successfully minted a PlatformId Id', async function () {
       platformId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       expect(platformId).to.be.equal('1')
     })
 
-    it('Alice can check the number of id minted', async function() {
+    it('Alice can check the number of id minted', async function () {
       await talentLayerPlatformID.connect(alice).numberMinted(alice.address)
       expect(await talentLayerPlatformID.numberMinted(alice.address)).to.be.equal('1')
     })
 
-    it('Alice can update the platform Data', async function() {
+    it('Alice can update the platform Data', async function () {
       await talentLayerPlatformID.connect(alice).updateProfileData('1', 'newPlatId')
 
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
@@ -84,7 +100,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it("ALice can't mint a platformId for someone else", async function() {
+    it("ALice can't mint a platformId for someone else", async function () {
       const mintRole = await talentLayerPlatformID.MINT_ROLE()
       await expect(talentLayerPlatformID.connect(alice).mintForAddress('platId2', dave.address)).to.be.revertedWith(
         `AccessControl: account ${alice.address.toLowerCase()} is missing role ${mintRole.toLowerCase()}`,
@@ -97,7 +113,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it("Alice's PlatformID ownership data is coherent", async function() {
+    it("Alice's PlatformID ownership data is coherent", async function () {
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
       const name = alicePlatformData.name
@@ -109,7 +125,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(idOwner).to.equal(alice.address)
     })
 
-    it('Alice should be able to set up and update platform fee', async function() {
+    it('Alice should be able to set up and update platform fee', async function () {
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       const adminRole = await talentLayerPlatformID.DEFAULT_ADMIN_ROLE()
 
@@ -127,14 +143,14 @@ describe('TalentLayer protocol global testing', function() {
       expect(newAlicePlatformData.fee).to.be.equal(6)
     })
 
-    it('The deployer can update the mint fee', async function() {
+    it('The deployer can update the mint fee', async function () {
       await talentLayerPlatformID.connect(deployer).updateMintFee(mintFee)
       const updatedMintFee = await talentLayerPlatformID.mintFee()
 
       expect(updatedMintFee).to.be.equal(mintFee)
     })
 
-    it('Bob can mint a platform id by paying the mint fee', async function() {
+    it('Bob can mint a platform id by paying the mint fee', async function () {
       const bobBalanceBefore = await bob.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerPlatformID.address)
 
@@ -157,7 +173,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
     })
 
-    it("The deployer can withdraw the contract's balance", async function() {
+    it("The deployer can withdraw the contract's balance", async function () {
       const deployerBalanceBefore = await deployer.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerPlatformID.address)
 
@@ -182,7 +198,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(0)
     })
 
-    it('The deployer can add a new available arbitrator', async function() {
+    it('The deployer can add a new available arbitrator', async function () {
       await talentLayerPlatformID.connect(deployer).addArbitrator(talentLayerArbitrator.address, true)
       const isValid = await talentLayerPlatformID.validArbitrators(talentLayerArbitrator.address)
       expect(isValid).to.be.true
@@ -191,7 +207,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(isInternal).to.be.true
     })
 
-    it('The platform owner can update the arbitrator only if is a valid one', async function() {
+    it('The platform owner can update the arbitrator only if is a valid one', async function () {
       const tx = talentLayerPlatformID.connect(alice).updateArbitrator(1, dave.address, [])
       await expect(tx).to.be.revertedWith('The address must be of a valid arbitrator')
 
@@ -205,7 +221,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(platformId).to.be.equal(1)
     })
 
-    it('The deployer can update the minimum arbitration fee timeout', async function() {
+    it('The deployer can update the minimum arbitration fee timeout', async function () {
       const minArbitrationFeeTimeout = 3600 * 10
       await talentLayerPlatformID.connect(deployer).updateMinArbitrationFeeTimeout(minArbitrationFeeTimeout)
       const updatedMinArbitrationFeeTimeout = await talentLayerPlatformID.minArbitrationFeeTimeout()
@@ -213,7 +229,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(updatedMinArbitrationFeeTimeout).to.be.equal(minArbitrationFeeTimeout)
     })
 
-    it('The platform owner can update the arbitration fee timeout', async function() {
+    it('The platform owner can update the arbitration fee timeout', async function () {
       const minArbitrationFeeTimeout = await talentLayerPlatformID.minArbitrationFeeTimeout()
       const tx = talentLayerPlatformID.connect(alice).updateArbitrationFeeTimeout(1, minArbitrationFeeTimeout - 1)
       await expect(tx).to.be.revertedWith('The timeout must be greater than the minimum timeout')
@@ -224,12 +240,12 @@ describe('TalentLayer protocol global testing', function() {
       expect(updatedArbitrationFeeTimeout).to.be.equal(arbitrationFeeTimeout)
     })
 
-    it('Only the owner of the platform can update its arbitrator', async function() {
+    it('Only the owner of the platform can update its arbitrator', async function () {
       const tx = talentLayerPlatformID.connect(bob).updateArbitrator(1, talentLayerArbitrator.address, [])
       await expect(tx).to.be.revertedWith("You're not the owner of this platform")
     })
 
-    it('The deployer can remove an available arbitrator', async function() {
+    it('The deployer can remove an available arbitrator', async function () {
       await talentLayerPlatformID.connect(deployer).removeArbitrator(talentLayerArbitrator.address)
       const isValid = await talentLayerPlatformID.validArbitrators(talentLayerArbitrator.address)
       expect(isValid).to.be.false
@@ -239,8 +255,8 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('Talent Layer ID contract test', function() {
-    it('Alice, Bob and Carol can mint a talentLayerId', async function() {
+  describe('Talent Layer ID contract test', function () {
+    it('Alice, Bob and Carol can mint a talentLayerId', async function () {
       await talentLayerID.connect(alice).mintWithPoh('1', 'alice')
       await talentLayerID.connect(bob).mintWithPoh('1', 'bob')
 
@@ -268,14 +284,14 @@ describe('TalentLayer protocol global testing', function() {
       expect(profileData.pohAddress).to.be.equal(carol.address)
     })
 
-    it('The deployer can update the mint fee', async function() {
+    it('The deployer can update the mint fee', async function () {
       await talentLayerID.connect(deployer).updateMintFee(mintFee)
       const updatedMintFee = await talentLayerID.mintFee()
 
       expect(updatedMintFee).to.be.equal(mintFee)
     })
 
-    it('Eve can mint a talentLayerId by paying the mint fee', async function() {
+    it('Eve can mint a talentLayerId by paying the mint fee', async function () {
       const eveBalanceBefore = await eve.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
 
@@ -297,7 +313,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
     })
 
-    it("The deployer can withdraw the contract's balance", async function() {
+    it("The deployer can withdraw the contract's balance", async function () {
       const deployerBalanceBefore = await deployer.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
 
@@ -319,7 +335,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(0)
     })
 
-    it('Deployer can mint TalentLayerID without poh for free', async function() {
+    it('Deployer can mint TalentLayerID without poh for free', async function () {
       const deployerBalanceBefore = await deployer.getBalance()
       const graceBalanceBefore = await grace.getBalance()
 
@@ -335,7 +351,7 @@ describe('TalentLayer protocol global testing', function() {
       await expect(graceBalanceAfter, 'Address minted for does not pay anything').to.be.equal(graceBalanceBefore)
     })
 
-    it('Alice can NOT mint TalentLayerIDs without paying the mint fee', async function() {
+    it('Alice can NOT mint TalentLayerIDs without paying the mint fee', async function () {
       await expect(
         talentLayerID.connect(alice).freeMint('1', heidi.address, 'heidi'),
         'Alice tries to mint talentLayer ID for heidi for free.',
@@ -343,32 +359,32 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('SimpleERC20 contract contract test', function() {
-    describe('Deployment', function() {
+  describe('SimpleERC20 contract contract test', function () {
+    describe('Deployment', function () {
       // it("Should be accessible", async function () {
       //   await loadFixture(deployTokenFixture);
       //   expect(await token.ping()).to.equal(1);
       // });
 
-      it('Should set the right deployer', async function() {
+      it('Should set the right deployer', async function () {
         expect(await token.owner()).to.equal(deployer.address)
       })
 
-      it('Should assign the total supply of tokens to the deployer', async function() {
+      it('Should assign the total supply of tokens to the deployer', async function () {
         // await loadFixture(deployTokenFixture);
         const deployerBalance = await token.balanceOf(deployer.address)
         const totalSupply = await token.totalSupply()
         expect(totalSupply).to.equal(deployerBalance)
       })
 
-      it('Should transfer 10000000 tokens to alice', async function() {
+      it('Should transfer 10000000 tokens to alice', async function () {
         // await loadFixture(deployTokenFixture);
         expect(token.transfer(alice.address, 10000000)).to.changeTokenBalances(token, [deployer, alice], [-1000, 1000])
       })
     })
 
-    describe('Token transactions.', function() {
-      it('Should transfer tokens between accounts', async function() {
+    describe('Token transactions.', function () {
+      it('Should transfer tokens between accounts', async function () {
         // await loadFixture(deployTokenFixture);
 
         // Transfer 50 tokens from deployer to alice
@@ -382,7 +398,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Should emit Transfer events.', async function() {
+      it('Should emit Transfer events.', async function () {
         // await loadFixture(deployTokenFixture);
 
         // Transfer 50 tokens from deployer to alice
@@ -396,7 +412,7 @@ describe('TalentLayer protocol global testing', function() {
           .withArgs(alice.address, bob.address, 50)
       })
 
-      it("Should revert when sender doesn't have enough tokens.", async function() {
+      it("Should revert when sender doesn't have enough tokens.", async function () {
         // await loadFixture(deployTokenFixture);
 
         const initialdeployerBalance = await token.balanceOf(deployer.address)
@@ -413,6 +429,22 @@ describe('TalentLayer protocol global testing', function() {
   })
 
   describe('Service Registry & Proposal contract test', function () {
+    it('Should revert if a user tries to whitelist a payment token without being the owner', async function () {
+      await expect(serviceRegistry.connect(alice).updateAllowedTokenList(token.address, true)).to.be.revertedWith(
+        'Ownable: caller is not the owner',
+      )
+    })
+
+    it('Should update the token list accordingly if the owner updates it', async function () {
+      const randomTokenAddress = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+
+      await serviceRegistry.connect(deployer).updateAllowedTokenList(randomTokenAddress, true)
+      expect(await serviceRegistry.isTokenAllowed(randomTokenAddress)).to.be.true
+
+      await serviceRegistry.connect(deployer).updateAllowedTokenList(randomTokenAddress, false)
+      expect(await serviceRegistry.isTokenAllowed(randomTokenAddress)).to.be.false
+    })
+
     it("Dave, who doesn't have TalentLayerID, can't create a service", async function () {
       await expect(serviceRegistry.connect(dave).createOpenServiceFromBuyer(1, 'haveNotTlid')).to.be.revertedWith(
         'You should have a TalentLayerId',
@@ -428,7 +460,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it('Alice the buyer can create a few Open service', async function() {
+    it('Alice the buyer can create a few Open service', async function () {
       // Alice will create 4 Open services fo the whole unit test process
       await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'CID1')
       const serviceData = await serviceRegistry.services(1)
@@ -458,13 +490,13 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it('Alice can update her service data', async function() {
+    it('Alice can update her service data', async function () {
       await serviceRegistry.connect(alice).updateServiceData(1, 'aliceUpdateHerFirstService')
       const serviceData = await serviceRegistry.services(1)
       expect(serviceData.serviceDataUri).to.be.equal('aliceUpdateHerFirstService')
     })
 
-    it('Bob can create his first proposal for an Open service n°1 from Alice', async function() {
+    it('Bob can create his first proposal for an Open service n°1 from Alice', async function () {
       // Proposal on the Open service n 1
       const bobTid = await talentLayerID.walletOfOwner(bob.address)
       const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
@@ -491,7 +523,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(proposalDataAfter.status.toString()).to.be.equal('0')
     })
 
-    it('Carol can create her first proposal (will be rejected by Alice) ', async function() {
+    it('Carol can create her first proposal (will be rejected by Alice) ', async function () {
       const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
       await serviceRegistry.connect(carol).createProposal(1, rateToken, 2, 'proposal1FromCarolToAlice1Service')
       await serviceRegistry.services(1)
@@ -500,7 +532,13 @@ describe('TalentLayer protocol global testing', function() {
       await serviceRegistry.getProposal(1, carolTid)
     })
 
-    it('Bob can update his first proposal ', async function() {
+    it('Should revert if Carol tries to create a proposal with a non-whitelisted payment token', async function () {
+      expect(
+        serviceRegistry.connect(carol).createProposal(1, nonListedRateToken, 2, 'proposal1FromCarolToAlice1Service'),
+      ).to.be.revertedWith('This token is not allowed')
+    })
+
+    it('Bob can update his first proposal ', async function () {
       const bobTid = await talentLayerID.walletOfOwner(bob.address)
       const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
 
@@ -514,9 +552,14 @@ describe('TalentLayer protocol global testing', function() {
       expect(proposalDataAfter.proposalDataUri).to.be.equal('updateProposal1FromBobToAlice1Service')
     })
 
-    it('Alice can validate Bob proposal', async function() {
+    it('Should revert if Bob updates his proposal with a non-whitelisted payment token ', async function () {
+      await expect(
+        serviceRegistry.connect(bob).updateProposal(1, nonListedRateToken, 2, 'updateProposal1FromBobToAlice1Service'),
+      ).to.be.revertedWith('This token is not allowed')
+    })
+
+    it('Alice can validate Bob proposal', async function () {
       const bobTid = await talentLayerID.walletOfOwner(bob.address)
-      const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
 
       const proposalDataBefore = await serviceRegistry.getProposal(1, bobTid)
       expect(proposalDataBefore.status.toString()).to.be.equal('0')
@@ -527,7 +570,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(proposalDataAfter.status.toString()).to.be.equal('1')
     })
 
-    it('Alice can reject Carol proposal ', async function() {
+    it('Alice can reject Carol proposal ', async function () {
       const carolTid = await talentLayerID.walletOfOwner(carol.address)
       await serviceRegistry.connect(alice).rejectProposal(1, carolTid)
 
@@ -536,8 +579,8 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('Escrow Contract test.', function() {
-    describe('Successful use of Escrow for a service using an ERC20 token.', function() {
+  describe('Escrow Contract test.', function () {
+    describe('Successful use of Escrow for a service using an ERC20 token.', function () {
       const amountBob = 1000000
       const amountCarol = 2000
       const serviceId = 2
@@ -546,20 +589,20 @@ describe('TalentLayer protocol global testing', function() {
       let proposalIdCarol = 0 //Will be set later
       let totalAmount = 0 //Will be set later
 
-      it('Alice can NOT deposit tokens to escrow yet.', async function() {
+      it('Alice can NOT deposit tokens to escrow yet.', async function () {
         await token.connect(alice).approve(talentLayerEscrow.address, amountBob)
         await expect(talentLayerEscrow.connect(alice).createTokenTransaction('_metaEvidence', serviceId, proposalIdBob))
           .to.be.reverted
       })
 
-      it('Bob can make a second proposal on the Alice service n°2', async function() {
+      it('Bob can make a second proposal on the Alice service n°2', async function () {
         proposalIdBob = await talentLayerID.walletOfOwner(bob.address)
         await serviceRegistry
           .connect(bob)
           .createProposal(serviceId, token.address, amountBob, 'proposal2FromBobToAlice2Service')
       })
 
-      it('Carol can make her second proposal on the Alice service n°2', async function() {
+      it('Carol can make her second proposal on the Alice service n°2', async function () {
         proposalIdCarol = await talentLayerID.walletOfOwner(carol.address)
         await serviceRegistry
           .connect(carol)
@@ -593,7 +636,7 @@ describe('TalentLayer protocol global testing', function() {
         expect(originPlatformEscrowFeeRate).to.equal(1400)
       })
 
-      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function() {
+      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function () {
         const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
         await talentLayerPlatformID.connect(alice).updatePlatformEscrowFeeRate(aliceUserId, 1100)
         const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
@@ -621,30 +664,30 @@ describe('TalentLayer protocol global testing', function() {
           .withArgs(serviceId, proposalIdBob, transactionId)
       })
 
-      it('The deposit should also validate the proposal.', async function() {
+      it('The deposit should also validate the proposal.', async function () {
         const proposal = await serviceRegistry.getProposal(serviceId, proposalIdBob)
         await expect(proposal.status.toString()).to.be.equal('1')
       })
 
-      it('The deposit should also update the service with transactionId, proposalId, and status.', async function() {
+      it('The deposit should also update the service with transactionId, proposalId, and status.', async function () {
         const service = await serviceRegistry.getService(serviceId)
         await expect(service.status.toString()).to.be.equal('1')
         await expect(service.transactionId.toString()).to.be.equal('0')
         await expect(service.sellerId.toString()).to.be.equal(proposalIdBob)
       })
 
-      it("Alice can NOT deposit funds for Carol's proposal.", async function() {
+      it("Alice can NOT deposit funds for Carol's proposal.", async function () {
         await token.connect(alice).approve(talentLayerEscrow.address, amountCarol)
         await expect(
           talentLayerEscrow.connect(alice).createTokenTransaction('_metaEvidence', serviceId, proposalIdCarol),
         ).to.be.reverted
       })
 
-      it('Carol should not be allowed to release escrow the service.', async function() {
+      it('Carol should not be allowed to release escrow the service.', async function () {
         await expect(talentLayerEscrow.connect(carol).release(transactionId, 10)).to.be.revertedWith('Access denied.')
       })
 
-      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function() {
+      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -669,7 +712,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function() {
+      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -695,19 +738,19 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Carol can NOT reimburse alice.', async function() {
+      it('Carol can NOT reimburse alice.', async function () {
         await expect(talentLayerEscrow.connect(carol).reimburse(transactionId, totalAmount / 4)).to.revertedWith(
           'Access denied.',
         )
       })
 
-      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function() {
+      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function () {
         await expect(talentLayerEscrow.connect(bob).reimburse(transactionId, totalAmount)).to.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function() {
+      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function () {
         const transaction = await talentLayerEscrow.connect(bob).reimburse(transactionId, amountBob / 4)
         /* When asking for the reimbursement of a fee-less amount,
          * we expect the amount reimbursed to include all fees (calculated by the function,
@@ -718,18 +761,16 @@ describe('TalentLayer protocol global testing', function() {
           [talentLayerEscrow.address, alice, bob],
           [-totalAmount / 4, totalAmount / 4, 0],
         )
-        await expect(transaction)
-          .to.emit(talentLayerEscrow, 'PaymentCompleted')
-          .withArgs(serviceId)
+        await expect(transaction).to.emit(talentLayerEscrow, 'PaymentCompleted').withArgs(serviceId)
       })
 
-      it('Alice can not release escrow because there is none left. ', async function() {
+      it('Alice can not release escrow because there is none left. ', async function () {
         await expect(talentLayerEscrow.connect(alice).release(transactionId, 1)).to.be.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Alice can claim her token balance.', async function() {
+      it('Alice can claim her token balance.', async function () {
         const platformBalance = await talentLayerEscrow.connect(alice).getClaimableFeeBalance(token.address)
         const transaction = await talentLayerEscrow.connect(alice).claim(platformId, token.address)
         await expect(transaction).to.changeTokenBalances(
@@ -739,7 +780,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('The protocol owner can claim his token balance.', async function() {
+      it('The protocol owner can claim his token balance.', async function () {
         let protocolOwnerBalance = await talentLayerEscrow.connect(deployer).getClaimableFeeBalance(token.address)
         // await talentLayerEscrow.updateProtocolWallet(alice.address);
         const transaction = await talentLayerEscrow.connect(deployer).claim(0, token.address)
@@ -751,7 +792,7 @@ describe('TalentLayer protocol global testing', function() {
       })
     })
 
-    describe('Successful use of Escrow for a service using ETH.', function() {
+    describe('Successful use of Escrow for a service using ETH.', function () {
       const amountBob = 1000000
       const amountCarol = 200
       const serviceId = 3
@@ -761,7 +802,7 @@ describe('TalentLayer protocol global testing', function() {
       let totalAmount = 0 //Will be set later
       const ethAddress = '0x0000000000000000000000000000000000000000'
 
-      it('Alice can NOT deposit eth to escrow yet.', async function() {
+      it('Alice can NOT deposit eth to escrow yet.', async function () {
         const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
         await talentLayerPlatformID.connect(alice).updatePlatformEscrowFeeRate(aliceUserId, 1100)
         const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
@@ -778,21 +819,21 @@ describe('TalentLayer protocol global testing', function() {
           .to.be.reverted
       })
 
-      it('Bob can register a proposal.', async function() {
+      it('Bob can register a proposal.', async function () {
         proposalIdBob = await talentLayerID.walletOfOwner(bob.address)
         await serviceRegistry
           .connect(bob)
           .createProposal(serviceId, ethAddress, amountBob, 'proposal3FromBobToAlice3Service')
       })
 
-      it('Carol can register a proposal.', async function() {
+      it('Carol can register a proposal.', async function () {
         proposalIdCarol = await talentLayerID.walletOfOwner(carol.address)
         await serviceRegistry
           .connect(carol)
           .createProposal(serviceId, ethAddress, amountCarol, 'proposal3FromCarolToAlice3Service')
       })
 
-      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function() {
+      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function () {
         const transaction = await talentLayerEscrow
           .connect(alice)
           .createETHTransaction('_metaEvidence', serviceId, proposalIdBob, { value: totalAmount })
@@ -806,19 +847,19 @@ describe('TalentLayer protocol global testing', function() {
           .withArgs(serviceId, proposalIdBob, transactionId)
       })
 
-      it('The deposit should also validate the proposal.', async function() {
+      it('The deposit should also validate the proposal.', async function () {
         const proposal = await serviceRegistry.getProposal(serviceId, proposalIdBob)
         await expect(proposal.status.toString()).to.be.equal('1')
       })
 
-      it('The deposit should also update the service with transactionId, proposalId, and status.', async function() {
+      it('The deposit should also update the service with transactionId, proposalId, and status.', async function () {
         const service = await serviceRegistry.getService(serviceId)
         await expect(service.status.toString()).to.be.equal('1')
         await expect(service.transactionId).to.be.equal(transactionId)
         await expect(service.sellerId).to.be.equal(proposalIdBob)
       })
 
-      it("Alice can NOT deposit funds for Carol's proposal, and NO event should emit.", async function() {
+      it("Alice can NOT deposit funds for Carol's proposal, and NO event should emit.", async function () {
         await token.connect(alice).approve(talentLayerEscrow.address, amountCarol)
         await expect(
           talentLayerEscrow
@@ -827,11 +868,11 @@ describe('TalentLayer protocol global testing', function() {
         ).to.be.reverted
       })
 
-      it('Carol should not be allowed to release escrow the service.', async function() {
+      it('Carol should not be allowed to release escrow the service.', async function () {
         await expect(talentLayerEscrow.connect(carol).release(transactionId, 10)).to.be.revertedWith('Access denied.')
       })
 
-      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function() {
+      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -856,7 +897,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function() {
+      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -880,19 +921,19 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Carol can NOT reimburse alice.', async function() {
+      it('Carol can NOT reimburse alice.', async function () {
         await expect(talentLayerEscrow.connect(carol).reimburse(transactionId, totalAmount / 4)).to.revertedWith(
           'Access denied.',
         )
       })
 
-      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function() {
+      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function () {
         await expect(talentLayerEscrow.connect(bob).reimburse(transactionId, totalAmount)).to.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function() {
+      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function () {
         const transaction = await talentLayerEscrow.connect(bob).reimburse(transactionId, amountBob / 4)
         /* When asking for the reimbursement of a fee-less amount,
          * we expect the amount reimbursed to include all fees (calculated by the function,
@@ -902,18 +943,16 @@ describe('TalentLayer protocol global testing', function() {
           [talentLayerEscrow.address, alice, bob],
           [-totalAmount / 4, totalAmount / 4, 0],
         )
-        await expect(transaction)
-          .to.emit(talentLayerEscrow, 'PaymentCompleted')
-          .withArgs(serviceId)
+        await expect(transaction).to.emit(talentLayerEscrow, 'PaymentCompleted').withArgs(serviceId)
       })
 
-      it('Alice can not release escrow because there is none left.', async function() {
+      it('Alice can not release escrow because there is none left.', async function () {
         await expect(talentLayerEscrow.connect(alice).release(transactionId, 10)).to.be.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Alice can claim her ETH balance.', async function() {
+      it('Alice can claim her ETH balance.', async function () {
         const platformEthBalance = await talentLayerEscrow.connect(alice).getClaimableFeeBalance(ethAddress)
         const transaction = await talentLayerEscrow.connect(alice).claim(platformId, ethAddress)
         await expect(transaction).to.changeEtherBalances(
@@ -922,7 +961,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('The Protocol owner can claim his ETH balance.', async function() {
+      it('The Protocol owner can claim his ETH balance.', async function () {
         const protocolEthBalance = await talentLayerEscrow.connect(deployer).getClaimableFeeBalance(ethAddress)
         const transaction = await talentLayerEscrow.connect(deployer).claim(0, ethAddress)
         await expect(transaction).to.changeEtherBalances(
@@ -955,7 +994,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it('Alice and Bob can write a review now and we can get review data', async function() {
+    it('Alice and Bob can write a review now and we can get review data', async function () {
       await talentLayerReview.connect(alice).addReview(2, 'cidReview1', 2, 1)
       await talentLayerReview.connect(bob).addReview(2, 'cidReview2', 4, 1)
 
@@ -969,8 +1008,8 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('Talent Layer Arbitrator contract test', function() {
-    it('the owner of the platform can update the arbitration price', async function() {
+  describe('Talent Layer Arbitrator contract test', function () {
+    it('the owner of the platform can update the arbitration price', async function () {
       const newArbitrationPrice = 1000
       const platformId = 1
 

--- a/test/batch/disputeResolution.ts
+++ b/test/batch/disputeResolution.ts
@@ -30,6 +30,7 @@ const arbitrationFeeTimeout = 3600 * 24
 /**
  * Deploys contract and sets up the context for dispute resolution.
  * @param arbitrationFeeTimeout the timeout for the arbitration fee
+ * @param tokenAddress the payment token used for this case
  * @returns the deployed contracts
  */
 async function deployAndSetup(
@@ -37,13 +38,11 @@ async function deployAndSetup(
   tokenAddress: string,
 ): Promise<[TalentLayerPlatformID, TalentLayerEscrow, TalentLayerArbitrator, ServiceRegistry]> {
   const [deployer, alice, bob, carol] = await ethers.getSigners()
-  const [
-    talentLayerID,
-    talentLayerPlatformID,
-    talentLayerEscrow,
-    talentLayerArbitrator,
-    serviceRegistry,
-  ] = await deploy(true)
+  const [talentLayerID, talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry] =
+    await deploy(true)
+
+  // Deployer whitelists a list of authorized tokens
+  await serviceRegistry.connect(deployer).updateAllowedTokenList(tokenAddress, true)
 
   // Grant Platform Id Mint role to Deployer and Bob
   const mintRole = await talentLayerPlatformID.MINT_ROLE()
@@ -76,7 +75,7 @@ async function deployAndSetup(
   return [talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry]
 }
 
-describe('Dispute Resolution, standard flow', function() {
+describe('Dispute Resolution, standard flow', function () {
   let alice: SignerWithAddress,
     bob: SignerWithAddress,
     carol: SignerWithAddress,
@@ -95,7 +94,7 @@ describe('Dispute Resolution, standard flow', function() {
   let currentTransactionAmount = transactionAmount
   const rulingId = 1
 
-  before(async function() {
+  before(async function () {
     ;[, alice, bob, carol, dave] = await ethers.getSigners()
     ;[talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry] = await deployAndSetup(
       arbitrationFeeTimeout,
@@ -108,11 +107,11 @@ describe('Dispute Resolution, standard flow', function() {
     platformEscrowFeeRate = platform.fee
   })
 
-  describe('Transaction creation', async function() {
+  describe('Transaction creation', async function () {
     let totalTransactionAmount: BigNumber
     let tx: ContractTransaction
 
-    before(async function() {
+    before(async function () {
       // Calculate total transaction amount, including fees
       totalTransactionAmount = transactionAmount.add(
         transactionAmount
@@ -125,20 +124,18 @@ describe('Dispute Resolution, standard flow', function() {
       })
     })
 
-    it('Funds are sent from buyer (Alice) to the escrow', async function() {
+    it('Funds are sent from buyer (Alice) to the escrow', async function () {
       await expect(tx).to.changeEtherBalances(
         [alice.address, talentLayerEscrow.address],
         [-totalTransactionAmount, totalTransactionAmount],
       )
     })
 
-    it('MetaEvidence is submitted', async function() {
-      await expect(tx)
-        .to.emit(talentLayerEscrow, 'MetaEvidence')
-        .withArgs(transactionId, metaEvidence)
+    it('MetaEvidence is submitted', async function () {
+      await expect(tx).to.emit(talentLayerEscrow, 'MetaEvidence').withArgs(transactionId, metaEvidence)
     })
 
-    it('MetaEvidence is submitted', async function() {
+    it('MetaEvidence is submitted', async function () {
       await expect(tx)
         .to.emit(talentLayerEscrow, 'TransactionCreated')
         .withArgs(
@@ -158,8 +155,8 @@ describe('Dispute Resolution, standard flow', function() {
     })
   })
 
-  describe('Partial release/reimbursement before a dispute', async function() {
-    it('On release funds are sent from escrow to seller (Bob)', async function() {
+  describe('Partial release/reimbursement before a dispute', async function () {
+    it('On release funds are sent from escrow to seller (Bob)', async function () {
       const tx = await talentLayerEscrow.connect(alice).release(transactionId, transactionReleasedAmount)
       await expect(tx).to.changeEtherBalances(
         [bob.address, talentLayerEscrow.address],
@@ -169,7 +166,7 @@ describe('Dispute Resolution, standard flow', function() {
       currentTransactionAmount = currentTransactionAmount.sub(transactionReleasedAmount)
     })
 
-    it('On reimbursement funds and fees are sent from escrow to buyer (Alice)', async function() {
+    it('On reimbursement funds and fees are sent from escrow to buyer (Alice)', async function () {
       const reimbursedFees = transactionReimbursedAmount
         .mul(protocolEscrowFeeRate + originPlatformEscrowFeeRate + platformEscrowFeeRate)
         .div(feeDivider)
@@ -185,98 +182,98 @@ describe('Dispute Resolution, standard flow', function() {
     })
   })
 
-  describe('Payment of arbitration fee by first party (sender in this case)', async function() {
-    it('Fails if is not called by the sender of the transaction', async function() {
+  describe('Payment of arbitration fee by first party (sender in this case)', async function () {
+    it('Fails if is not called by the sender of the transaction', async function () {
       const tx = talentLayerEscrow.connect(bob).payArbitrationFeeBySender(transactionId, {
         value: arbitrationCost,
       })
       await expect(tx).to.be.revertedWith('The caller must be the sender.')
     })
 
-    it('Fails if the amount of ETH sent is less than the arbitration cost', async function() {
+    it('Fails if the amount of ETH sent is less than the arbitration cost', async function () {
       const tx = talentLayerEscrow.connect(alice).payArbitrationFeeBySender(transactionId, {
         value: arbitrationCost.sub(1),
       })
       await expect(tx).to.be.revertedWith('The sender fee must be equal to the arbitration cost.')
     })
 
-    describe('Successfull payment of arbitration fee', async function() {
+    describe('Successfull payment of arbitration fee', async function () {
       let tx: ContractTransaction
 
-      before(async function() {
+      before(async function () {
         tx = await talentLayerEscrow.connect(alice).payArbitrationFeeBySender(transactionId, {
           value: arbitrationCost,
         })
       })
 
-      it('Arbitration fee is sent from sender (Alice) to escrow', async function() {
+      it('Arbitration fee is sent from sender (Alice) to escrow', async function () {
         await expect(tx).to.changeEtherBalances(
           [alice.address, talentLayerEscrow.address],
           [-arbitrationCost, arbitrationCost],
         )
       })
 
-      it('The fee amount paid by the sender is stored in the transaction', async function() {
+      it('The fee amount paid by the sender is stored in the transaction', async function () {
         const transaction = await talentLayerEscrow.connect(alice).getTransactionDetails(transactionId)
         expect(transaction.senderFee).to.be.eq(arbitrationCost)
       })
 
-      it('The transaction status becomes "WaitingReceiver"', async function() {
+      it('The transaction status becomes "WaitingReceiver"', async function () {
         const transaction = await talentLayerEscrow.connect(alice).getTransactionDetails(transactionId)
         expect(transaction.status).to.be.eq(TransactionStatus.WaitingReceiver)
       })
     })
   })
 
-  describe('Attempt to end dispute before arbitration fee timeout has passed', async function() {
-    it('Fails if is not called by the sender of the transaction', async function() {
+  describe('Attempt to end dispute before arbitration fee timeout has passed', async function () {
+    it('Fails if is not called by the sender of the transaction', async function () {
       const tx = talentLayerEscrow.connect(alice).timeOutBySender(transactionId)
       await expect(tx).to.be.revertedWith('Timeout time has not passed yet.')
     })
   })
 
-  describe('Payment of arbitration fee by second party (receiver in this case) and creation of dispute', async function() {
-    it('Fails if is not called by the receiver of the transaction', async function() {
+  describe('Payment of arbitration fee by second party (receiver in this case) and creation of dispute', async function () {
+    it('Fails if is not called by the receiver of the transaction', async function () {
       const tx = talentLayerEscrow.connect(alice).payArbitrationFeeByReceiver(transactionId, {
         value: arbitrationCost,
       })
       await expect(tx).to.be.revertedWith('The caller must be the receiver.')
     })
 
-    it('Fails if the amount of ETH sent is less than the arbitration cost', async function() {
+    it('Fails if the amount of ETH sent is less than the arbitration cost', async function () {
       const tx = talentLayerEscrow.connect(bob).payArbitrationFeeByReceiver(transactionId, {
         value: arbitrationCost.sub(1),
       })
       await expect(tx).to.be.revertedWith('The receiver fee must be equal to the arbitration cost.')
     })
 
-    describe('Successfull payment of arbitration fee', async function() {
+    describe('Successfull payment of arbitration fee', async function () {
       let tx: ContractTransaction
 
-      before(async function() {
+      before(async function () {
         tx = await talentLayerEscrow.connect(bob).payArbitrationFeeByReceiver(transactionId, {
           value: arbitrationCost,
         })
       })
 
-      it('The arbitration fee is sent to the arbitrator', async function() {
+      it('The arbitration fee is sent to the arbitrator', async function () {
         await expect(tx).to.changeEtherBalances(
           [bob.address, talentLayerEscrow.address, talentLayerArbitrator.address],
           [-arbitrationCost, 0, arbitrationCost],
         )
       })
 
-      it('The fee amount paid by the receiver is stored in the transaction', async function() {
+      it('The fee amount paid by the receiver is stored in the transaction', async function () {
         const transaction = await talentLayerEscrow.connect(bob).getTransactionDetails(transactionId)
         expect(transaction.receiverFee).to.be.eq(arbitrationCost)
       })
 
-      it('The transaction status becomes "DisputeCreated"', async function() {
+      it('The transaction status becomes "DisputeCreated"', async function () {
         const transaction = await talentLayerEscrow.connect(bob).getTransactionDetails(transactionId)
         expect(transaction.status).to.be.eq(TransactionStatus.DisputeCreated)
       })
 
-      it('A dispute is created, with the correct data', async function() {
+      it('A dispute is created, with the correct data', async function () {
         const dispute = await talentLayerArbitrator.disputes(disputeId)
         expect(dispute.arbitrated).to.be.eq(talentLayerEscrow.address)
         expect(dispute.fee).to.be.eq(arbitrationCost)
@@ -290,26 +287,26 @@ describe('Dispute Resolution, standard flow', function() {
     })
   })
 
-  describe('Attempt to release/reimburse after a dispute', async function() {
-    it('Release fails since ther must be no dispute to release', async function() {
+  describe('Attempt to release/reimburse after a dispute', async function () {
+    it('Release fails since ther must be no dispute to release', async function () {
       const tx = talentLayerEscrow.connect(alice).release(transactionId, transactionReleasedAmount)
       await expect(tx).to.be.revertedWith("The transaction shouldn't be disputed.")
     })
 
-    it('Reimbursement fails since ther must be no dispute to reimburse', async function() {
+    it('Reimbursement fails since ther must be no dispute to reimburse', async function () {
       const tx = talentLayerEscrow.connect(bob).reimburse(transactionId, transactionReimbursedAmount)
       await expect(tx).to.be.revertedWith("The transaction shouldn't be disputed.")
     })
   })
 
-  describe('Submission of Evidence', async function() {
-    it('Fails if evidence is not submitted by either sender or receiver of the transaction', async function() {
+  describe('Submission of Evidence', async function () {
+    it('Fails if evidence is not submitted by either sender or receiver of the transaction', async function () {
       const daveEvidence = "Dave's evidence"
       const tx = talentLayerEscrow.connect(dave).submitEvidence(transactionId, daveEvidence)
       await expect(tx).to.be.revertedWith('The caller must be the sender or the receiver.')
     })
 
-    it('The evidence event is emitted when the sender submits it', async function() {
+    it('The evidence event is emitted when the sender submits it', async function () {
       const aliceEvidence = "Alice's evidence"
       const tx = await talentLayerEscrow.connect(alice).submitEvidence(transactionId, aliceEvidence)
       await expect(tx)
@@ -317,7 +314,7 @@ describe('Dispute Resolution, standard flow', function() {
         .withArgs(talentLayerArbitrator.address, transactionId, alice.address, aliceEvidence)
     })
 
-    it('The evidence event is emitted when the receiver submits it', async function() {
+    it('The evidence event is emitted when the receiver submits it', async function () {
       const bobEvidence = "Bob's evidence"
       const tx = await talentLayerEscrow.connect(bob).submitEvidence(transactionId, bobEvidence)
       await expect(tx)
@@ -326,26 +323,26 @@ describe('Dispute Resolution, standard flow', function() {
     })
   })
 
-  describe('Submission of a ruling', async function() {
-    it('Fails if ruling is not given by the arbitrator contract', async function() {
+  describe('Submission of a ruling', async function () {
+    it('Fails if ruling is not given by the arbitrator contract', async function () {
       const tx = talentLayerEscrow.connect(dave).rule(disputeId, rulingId)
       await expect(tx).to.be.revertedWith('The caller must be the arbitrator.')
     })
 
-    it('Fails if ruling is not given by the platform owner', async function() {
+    it('Fails if ruling is not given by the platform owner', async function () {
       const tx = talentLayerArbitrator.connect(dave).giveRuling(disputeId, rulingId)
       await expect(tx).to.be.revertedWith("You're not the owner of the platform")
     })
 
-    describe('Successfull submission of a ruling', async function() {
+    describe('Successfull submission of a ruling', async function () {
       let tx: ContractTransaction
 
-      before(async function() {
+      before(async function () {
         // Rule in favor of the sender (Alice)
         tx = await talentLayerArbitrator.connect(carol).giveRuling(disputeId, rulingId)
       })
 
-      it('The winner of the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function() {
+      it('The winner of the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function () {
         // Calculate total sent amount, including fees and arbitration cost reimbursement
         const totalAmountSent = currentTransactionAmount
           .add(
@@ -361,31 +358,31 @@ describe('Dispute Resolution, standard flow', function() {
         )
       })
 
-      it('The owner of the platform (Carol) receives the arbitration fee', async function() {
+      it('The owner of the platform (Carol) receives the arbitration fee', async function () {
         await expect(tx).to.changeEtherBalances(
           [carol.address, talentLayerArbitrator.address],
           [arbitrationCost, -arbitrationCost],
         )
       })
 
-      it('The status of the transaction becomes "Resolved"', async function() {
+      it('The status of the transaction becomes "Resolved"', async function () {
         const transaction = await talentLayerEscrow.connect(alice).getTransactionDetails(transactionId)
         expect(transaction.status).to.be.eq(TransactionStatus.Resolved)
       })
 
-      it('Dispute data is updated', async function() {
+      it('Dispute data is updated', async function () {
         const status = await talentLayerArbitrator.disputeStatus(disputeId)
         const ruling = await talentLayerArbitrator.currentRuling(disputeId)
         expect(status).to.be.eq(DisputeStatus.Solved)
         expect(ruling).to.be.eq(rulingId)
       })
 
-      it('Sets the service as finished', async function() {
+      it('Sets the service as finished', async function () {
         const service = await serviceRegistry.getService(serviceId)
         expect(service.status).to.be.eq(2)
       })
 
-      it('Emits the Payment event', async function() {
+      it('Emits the Payment event', async function () {
         await expect(tx)
           .to.emit(talentLayerEscrow, 'Payment')
           .withArgs(transactionId, PaymentType.Reimburse, currentTransactionAmount, ethAddress, serviceId)
@@ -394,13 +391,13 @@ describe('Dispute Resolution, standard flow', function() {
   })
 })
 
-describe('Dispute Resolution, with party failing to pay arbitration fee on time', function() {
+describe('Dispute Resolution, with party failing to pay arbitration fee on time', function () {
   let alice: SignerWithAddress,
     talentLayerPlatformID: TalentLayerPlatformID,
     talentLayerEscrow: TalentLayerEscrow,
     totalTransactionAmount: BigNumber
 
-  before(async function() {
+  before(async function () {
     ;[, alice] = await ethers.getSigners()
     ;[talentLayerPlatformID, talentLayerEscrow] = await deployAndSetup(arbitrationFeeTimeout, ethAddress)
 
@@ -426,26 +423,26 @@ describe('Dispute Resolution, with party failing to pay arbitration fee on time'
     await time.increase(arbitrationFeeTimeout)
   })
 
-  describe('One party (in our case receiver) fails to pay arbitration fee on time', function() {
+  describe('One party (in our case receiver) fails to pay arbitration fee on time', function () {
     let tx: ContractTransaction
 
-    before(async function() {
+    before(async function () {
       tx = await talentLayerEscrow.connect(alice).timeOutBySender(transactionId)
     })
 
-    it('The sender wins the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function() {
+    it('The sender wins the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function () {
       const sentAmount = totalTransactionAmount.add(arbitrationCost)
       await expect(tx).to.changeEtherBalances([alice.address, talentLayerEscrow.address], [sentAmount, -sentAmount])
     })
 
-    it('The status of the transaction becomes "Resolved"', async function() {
+    it('The status of the transaction becomes "Resolved"', async function () {
       const transaction = await talentLayerEscrow.connect(alice).getTransactionDetails(transactionId)
       expect(transaction.status).to.be.eq(TransactionStatus.Resolved)
     })
   })
 })
 
-describe('Dispute Resolution, arbitrator abstaining from giving a ruling', function() {
+describe('Dispute Resolution, arbitrator abstaining from giving a ruling', function () {
   let deployer: SignerWithAddress,
     alice: SignerWithAddress,
     bob: SignerWithAddress,
@@ -458,7 +455,7 @@ describe('Dispute Resolution, arbitrator abstaining from giving a ruling', funct
     originPlatformEscrowFeeRate: number,
     platformEscrowFeeRate: number
 
-  before(async function() {
+  before(async function () {
     ;[deployer, alice, bob, carol] = await ethers.getSigners()
     ;[talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator] = await deployAndSetup(
       arbitrationFeeTimeout,
@@ -489,17 +486,17 @@ describe('Dispute Resolution, arbitrator abstaining from giving a ruling', funct
     })
   })
 
-  describe('The arbitrator abstains from giving a ruling', async function() {
+  describe('The arbitrator abstains from giving a ruling', async function () {
     let tx: ContractTransaction, halfTransactionAmount: BigNumber, halfArbitrationCost: BigNumber, halfAmount: BigNumber
 
-    before(async function() {
+    before(async function () {
       tx = await talentLayerArbitrator.connect(carol).giveRuling(transactionId, 0)
       halfTransactionAmount = transactionAmount.div(2)
       halfArbitrationCost = arbitrationCost.div(2)
       halfAmount = halfTransactionAmount.add(halfArbitrationCost)
     })
 
-    it('Split funds and arbitration fee half and half between the parties', async function() {
+    it('Split funds and arbitration fee half and half between the parties', async function () {
       // Transaction fees reimbursed to sender
       const fees = halfTransactionAmount
         .mul(protocolEscrowFeeRate + originPlatformEscrowFeeRate + platformEscrowFeeRate)
@@ -514,7 +511,7 @@ describe('Dispute Resolution, arbitrator abstaining from giving a ruling', funct
       )
     })
 
-    it('Increases platform token balance by the platform fee', async function() {
+    it('Increases platform token balance by the platform fee', async function () {
       const carolPlatformBalance = await talentLayerEscrow.connect(carol).getClaimableFeeBalance(ethAddress)
       const platformEscrowFeeRatesPaid = halfTransactionAmount
         .mul(originPlatformEscrowFeeRate + platformEscrowFeeRate)
@@ -522,13 +519,13 @@ describe('Dispute Resolution, arbitrator abstaining from giving a ruling', funct
       expect(carolPlatformBalance).to.be.eq(platformEscrowFeeRatesPaid)
     })
 
-    it('Increases protocol token balance by the protocol fee', async function() {
+    it('Increases protocol token balance by the protocol fee', async function () {
       const protocolBalance = await talentLayerEscrow.connect(deployer).getClaimableFeeBalance(ethAddress)
       const protocolEscrowFeeRatesPaid = halfTransactionAmount.mul(protocolEscrowFeeRate).div(feeDivider)
       expect(protocolBalance).to.be.eq(protocolEscrowFeeRatesPaid)
     })
 
-    it('Emits the Payment events', async function() {
+    it('Emits the Payment events', async function () {
       await expect(tx)
         .to.emit(talentLayerEscrow, 'Payment')
         .withArgs(transactionId, PaymentType.Release, halfTransactionAmount, ethAddress, serviceId)
@@ -540,28 +537,34 @@ describe('Dispute Resolution, arbitrator abstaining from giving a ruling', funct
   })
 })
 
-describe('Dispute Resolution, with ERC20 token transaction', function() {
-  let alice: SignerWithAddress,
+describe('Dispute Resolution, with ERC20 token transaction', function () {
+  let deployer: SignerWithAddress,
+    alice: SignerWithAddress,
     bob: SignerWithAddress,
     carol: SignerWithAddress,
     talentLayerPlatformID: TalentLayerPlatformID,
     talentLayerEscrow: TalentLayerEscrow,
     talentLayerArbitrator: TalentLayerArbitrator,
     simpleERC20: SimpleERC20,
+    serviceRegistry: ServiceRegistry,
     totalTransactionAmount: BigNumber
 
   const rulingId = 1
 
-  before(async function() {
-    ;[, alice, bob, carol] = await ethers.getSigners()
+  before(async function () {
+    ;[deployer, alice, bob, carol] = await ethers.getSigners()
 
     // Deploy SimpleERC20 token and setup
     const SimpleERC20 = await ethers.getContractFactory('SimpleERC20')
     simpleERC20 = await SimpleERC20.deploy()
-    ;[talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator] = await deployAndSetup(
+    ;[talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry] = await deployAndSetup(
       arbitrationFeeTimeout,
       simpleERC20.address,
     )
+
+    if (!(await serviceRegistry.isTokenAllowed(simpleERC20.address))) {
+      await serviceRegistry.connect(deployer).updateAllowedTokenList(simpleERC20.address, true)
+    }
 
     const protocolEscrowFeeRate = await talentLayerEscrow.protocolEscrowFeeRate()
     const originPlatformEscrowFeeRate = await talentLayerEscrow.originPlatformEscrowFeeRate()
@@ -592,15 +595,15 @@ describe('Dispute Resolution, with ERC20 token transaction', function() {
     })
   })
 
-  describe('Submission of a ruling', async function() {
+  describe('Submission of a ruling', async function () {
     let tx: ContractTransaction
 
-    before(async function() {
+    before(async function () {
       // Rule in favor of the sender (Alice)
       tx = await talentLayerArbitrator.connect(carol).giveRuling(disputeId, rulingId)
     })
 
-    it('The winner of the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function() {
+    it('The winner of the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function () {
       await expect(tx).to.changeTokenBalances(
         simpleERC20,
         [alice.address, talentLayerEscrow.address],

--- a/test/batch/serviceRegistryV2.ts
+++ b/test/batch/serviceRegistryV2.ts
@@ -1,7 +1,7 @@
 const { upgrades } = require('hardhat')
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
-import { BigNumber, ContractTransaction } from 'ethers'
+import { BigNumber } from 'ethers'
 import { ethers } from 'hardhat'
 import {
   ServiceRegistry,
@@ -25,13 +25,11 @@ async function deployAndSetup(
   tokenAddress: string,
 ): Promise<[TalentLayerPlatformID, TalentLayerEscrow, TalentLayerArbitrator, ServiceRegistry]> {
   const [deployer, alice, bob, carol] = await ethers.getSigners()
-  const [
-    talentLayerID,
-    talentLayerPlatformID,
-    talentLayerEscrow,
-    talentLayerArbitrator,
-    serviceRegistry,
-  ] = await deploy(false)
+  const [talentLayerID, talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry] =
+    await deploy(false)
+
+  // Deployer whitelists a list of authorized tokens
+  await serviceRegistry.connect(deployer).updateAllowedTokenList(tokenAddress, true)
 
   // Deployer mints Platform Id for Carol
   const platformName = 'HireVibes'
@@ -50,7 +48,7 @@ async function deployAndSetup(
   return [talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry]
 }
 
-describe('Service registry V2 migration testing', function() {
+describe('Service registry V2 migration testing', function () {
   let alice: SignerWithAddress,
     bob: SignerWithAddress,
     carol: SignerWithAddress,
@@ -61,15 +59,15 @@ describe('Service registry V2 migration testing', function() {
     serviceRegistry: ServiceRegistry,
     serviceRegistryV2: ServiceRegistryV2
 
-  before(async function() {
+  before(async function () {
     ;[, alice, bob, carol, dave] = await ethers.getSigners()
     ;[talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry] = await deployAndSetup(
       ethAddress,
     )
   })
 
-  describe('Migrate to V2', async function() {
-    it('Should deploy the V2 keeping the same address', async function() {
+  describe('Migrate to V2', async function () {
+    it('Should deploy the V2 keeping the same address', async function () {
       const ServiceRegistryV2 = await ethers.getContractFactory('ServiceRegistryV2')
       serviceRegistryV2 = await upgrades.upgradeProxy(serviceRegistry.address, ServiceRegistryV2)
 

--- a/test/batch/talentLayerEscrowV2.ts
+++ b/test/batch/talentLayerEscrowV2.ts
@@ -25,6 +25,9 @@ async function deployAndSetup(
   const [talentLayerID, talentLayerPlatformID, talentLayerEscrow, talentLayerArbitrator, serviceRegistry] =
     await deploy(false)
 
+  // Deployer whitelists a list of authorized tokens
+  await serviceRegistry.connect(deployer).updateAllowedTokenList(tokenAddress, true)
+
   // Deployer mints Platform Id for Carol
   const platformName = 'HireVibes'
   await talentLayerPlatformID.connect(deployer).mintForAddress(platformName, carol.address)


### PR DESCRIPTION
# New PR: 201 - Protocol tokens allow list

## Useful info

- Trello: https://trello.com/c/YPITeZnN/201-protocol-tokens-allow-list
- Description: Added a whitelist of allowed payment tokens in serviceRegistry contract + unit tests + hardhat script to add or remove token from whitelist

## Auto-Review checklist

- [ ] Check if there is no merge conflict
- [ ] If you have new .env variable, check if you add it in the .env.example file


## Typing

- [ ] Check solhint feedbacks: `npm run solhint`
