### PR TITLE
Fix contracts typing in test

### DIFF
--- a/test/batch/TalentLayer.ts
+++ b/test/batch/TalentLayer.ts
@@ -4,7 +4,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { BigNumber, Contract } from 'ethers'
 import { deploy } from '../utils/deploy'
 
-describe('TalentLayer protocol global testing', function() {
+describe('TalentLayer protocol global testing', function () {
   // we dedine the types of the variables we will use
   let deployer: SignerWithAddress,
     alice: SignerWithAddress,
@@ -27,7 +27,7 @@ describe('TalentLayer protocol global testing', function() {
     platformId: string,
     mintFee: number
 
-  before(async function() {
+  before(async function () {
     // Get the Signers
     ;[deployer, alice, bob, carol, dave, eve, frank, grace, heidi] = await ethers.getSigners()
     ;[
@@ -55,18 +55,18 @@ describe('TalentLayer protocol global testing', function() {
     mintFee = 100
   })
 
-  describe('Platform Id contract test', async function() {
-    it('Alice successfully minted a PlatformId Id', async function() {
+  describe('Platform Id contract test', async function () {
+    it('Alice successfully minted a PlatformId Id', async function () {
       platformId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       expect(platformId).to.be.equal('1')
     })
 
-    it('Alice can check the number of id minted', async function() {
+    it('Alice can check the number of id minted', async function () {
       await talentLayerPlatformID.connect(alice).numberMinted(alice.address)
       expect(await talentLayerPlatformID.numberMinted(alice.address)).to.be.equal('1')
     })
 
-    it('Alice can update the platform Data', async function() {
+    it('Alice can update the platform Data', async function () {
       await talentLayerPlatformID.connect(alice).updateProfileData('1', 'newPlatId')
 
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
@@ -84,7 +84,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it("ALice can't mint a platformId for someone else", async function() {
+    it("ALice can't mint a platformId for someone else", async function () {
       const mintRole = await talentLayerPlatformID.MINT_ROLE()
       await expect(talentLayerPlatformID.connect(alice).mintForAddress('platId2', dave.address)).to.be.revertedWith(
         `AccessControl: account ${alice.address.toLowerCase()} is missing role ${mintRole.toLowerCase()}`,
@@ -97,7 +97,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it("Alice's PlatformID ownership data is coherent", async function() {
+    it("Alice's PlatformID ownership data is coherent", async function () {
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
       const name = alicePlatformData.name
@@ -109,7 +109,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(idOwner).to.equal(alice.address)
     })
 
-    it('Alice should be able to set up and update platform fee', async function() {
+    it('Alice should be able to set up and update platform fee', async function () {
       const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
       const adminRole = await talentLayerPlatformID.DEFAULT_ADMIN_ROLE()
 
@@ -127,14 +127,14 @@ describe('TalentLayer protocol global testing', function() {
       expect(newAlicePlatformData.fee).to.be.equal(6)
     })
 
-    it('The deployer can update the mint fee', async function() {
+    it('The deployer can update the mint fee', async function () {
       await talentLayerPlatformID.connect(deployer).updateMintFee(mintFee)
       const updatedMintFee = await talentLayerPlatformID.mintFee()
 
       expect(updatedMintFee).to.be.equal(mintFee)
     })
 
-    it('Bob can mint a platform id by paying the mint fee', async function() {
+    it('Bob can mint a platform id by paying the mint fee', async function () {
       const bobBalanceBefore = await bob.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerPlatformID.address)
 
@@ -157,7 +157,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
     })
 
-    it("The deployer can withdraw the contract's balance", async function() {
+    it("The deployer can withdraw the contract's balance", async function () {
       const deployerBalanceBefore = await deployer.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerPlatformID.address)
 
@@ -182,7 +182,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(0)
     })
 
-    it('The deployer can add a new available arbitrator', async function() {
+    it('The deployer can add a new available arbitrator', async function () {
       await talentLayerPlatformID.connect(deployer).addArbitrator(talentLayerArbitrator.address, true)
       const isValid = await talentLayerPlatformID.validArbitrators(talentLayerArbitrator.address)
       expect(isValid).to.be.true
@@ -191,7 +191,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(isInternal).to.be.true
     })
 
-    it('The platform owner can update the arbitrator only if is a valid one', async function() {
+    it('The platform owner can update the arbitrator only if is a valid one', async function () {
       const tx = talentLayerPlatformID.connect(alice).updateArbitrator(1, dave.address, [])
       await expect(tx).to.be.revertedWith('The address must be of a valid arbitrator')
 
@@ -205,7 +205,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(platformId).to.be.equal(1)
     })
 
-    it('The deployer can update the minimum arbitration fee timeout', async function() {
+    it('The deployer can update the minimum arbitration fee timeout', async function () {
       const minArbitrationFeeTimeout = 3600 * 10
       await talentLayerPlatformID.connect(deployer).updateMinArbitrationFeeTimeout(minArbitrationFeeTimeout)
       const updatedMinArbitrationFeeTimeout = await talentLayerPlatformID.minArbitrationFeeTimeout()
@@ -213,7 +213,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(updatedMinArbitrationFeeTimeout).to.be.equal(minArbitrationFeeTimeout)
     })
 
-    it('The platform owner can update the arbitration fee timeout', async function() {
+    it('The platform owner can update the arbitration fee timeout', async function () {
       const minArbitrationFeeTimeout = await talentLayerPlatformID.minArbitrationFeeTimeout()
       const tx = talentLayerPlatformID.connect(alice).updateArbitrationFeeTimeout(1, minArbitrationFeeTimeout - 1)
       await expect(tx).to.be.revertedWith('The timeout must be greater than the minimum timeout')
@@ -224,12 +224,12 @@ describe('TalentLayer protocol global testing', function() {
       expect(updatedArbitrationFeeTimeout).to.be.equal(arbitrationFeeTimeout)
     })
 
-    it('Only the owner of the platform can update its arbitrator', async function() {
+    it('Only the owner of the platform can update its arbitrator', async function () {
       const tx = talentLayerPlatformID.connect(bob).updateArbitrator(1, talentLayerArbitrator.address, [])
       await expect(tx).to.be.revertedWith("You're not the owner of this platform")
     })
 
-    it('The deployer can remove an available arbitrator', async function() {
+    it('The deployer can remove an available arbitrator', async function () {
       await talentLayerPlatformID.connect(deployer).removeArbitrator(talentLayerArbitrator.address)
       const isValid = await talentLayerPlatformID.validArbitrators(talentLayerArbitrator.address)
       expect(isValid).to.be.false
@@ -239,8 +239,8 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('Talent Layer ID contract test', function() {
-    it('Alice, Bob and Carol can mint a talentLayerId', async function() {
+  describe('Talent Layer ID contract test', function () {
+    it('Alice, Bob and Carol can mint a talentLayerId', async function () {
       await talentLayerID.connect(alice).mintWithPoh('1', 'alice')
       await talentLayerID.connect(bob).mintWithPoh('1', 'bob')
 
@@ -268,14 +268,14 @@ describe('TalentLayer protocol global testing', function() {
       expect(profileData.pohAddress).to.be.equal(carol.address)
     })
 
-    it('The deployer can update the mint fee', async function() {
+    it('The deployer can update the mint fee', async function () {
       await talentLayerID.connect(deployer).updateMintFee(mintFee)
       const updatedMintFee = await talentLayerID.mintFee()
 
       expect(updatedMintFee).to.be.equal(mintFee)
     })
 
-    it('Eve can mint a talentLayerId by paying the mint fee', async function() {
+    it('Eve can mint a talentLayerId by paying the mint fee', async function () {
       const eveBalanceBefore = await eve.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
 
@@ -297,7 +297,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
     })
 
-    it("The deployer can withdraw the contract's balance", async function() {
+    it("The deployer can withdraw the contract's balance", async function () {
       const deployerBalanceBefore = await deployer.getBalance()
       const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
 
@@ -319,7 +319,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(contractBalanceAfter).to.be.equal(0)
     })
 
-    it('Deployer can mint TalentLayerID without poh for free', async function() {
+    it('Deployer can mint TalentLayerID without poh for free', async function () {
       const deployerBalanceBefore = await deployer.getBalance()
       const graceBalanceBefore = await grace.getBalance()
 
@@ -335,7 +335,7 @@ describe('TalentLayer protocol global testing', function() {
       await expect(graceBalanceAfter, 'Address minted for does not pay anything').to.be.equal(graceBalanceBefore)
     })
 
-    it('Alice can NOT mint TalentLayerIDs without paying the mint fee', async function() {
+    it('Alice can NOT mint TalentLayerIDs without paying the mint fee', async function () {
       await expect(
         talentLayerID.connect(alice).freeMint('1', heidi.address, 'heidi'),
         'Alice tries to mint talentLayer ID for heidi for free.',
@@ -343,32 +343,32 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('SimpleERC20 contract contract test', function() {
-    describe('Deployment', function() {
+  describe('SimpleERC20 contract contract test', function () {
+    describe('Deployment', function () {
       // it("Should be accessible", async function () {
       //   await loadFixture(deployTokenFixture);
       //   expect(await token.ping()).to.equal(1);
       // });
 
-      it('Should set the right deployer', async function() {
+      it('Should set the right deployer', async function () {
         expect(await token.owner()).to.equal(deployer.address)
       })
 
-      it('Should assign the total supply of tokens to the deployer', async function() {
+      it('Should assign the total supply of tokens to the deployer', async function () {
         // await loadFixture(deployTokenFixture);
         const deployerBalance = await token.balanceOf(deployer.address)
         const totalSupply = await token.totalSupply()
         expect(totalSupply).to.equal(deployerBalance)
       })
 
-      it('Should transfer 10000000 tokens to alice', async function() {
+      it('Should transfer 10000000 tokens to alice', async function () {
         // await loadFixture(deployTokenFixture);
         expect(token.transfer(alice.address, 10000000)).to.changeTokenBalances(token, [deployer, alice], [-1000, 1000])
       })
     })
 
-    describe('Token transactions.', function() {
-      it('Should transfer tokens between accounts', async function() {
+    describe('Token transactions.', function () {
+      it('Should transfer tokens between accounts', async function () {
         // await loadFixture(deployTokenFixture);
 
         // Transfer 50 tokens from deployer to alice
@@ -382,7 +382,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Should emit Transfer events.', async function() {
+      it('Should emit Transfer events.', async function () {
         // await loadFixture(deployTokenFixture);
 
         // Transfer 50 tokens from deployer to alice
@@ -396,7 +396,7 @@ describe('TalentLayer protocol global testing', function() {
           .withArgs(alice.address, bob.address, 50)
       })
 
-      it("Should revert when sender doesn't have enough tokens.", async function() {
+      it("Should revert when sender doesn't have enough tokens.", async function () {
         // await loadFixture(deployTokenFixture);
 
         const initialdeployerBalance = await token.balanceOf(deployer.address)
@@ -428,7 +428,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it('Alice the buyer can create a few Open service', async function() {
+    it('Alice the buyer can create a few Open service', async function () {
       // Alice will create 4 Open services fo the whole unit test process
       await serviceRegistry.connect(alice).createOpenServiceFromBuyer(1, 'CID1')
       const serviceData = await serviceRegistry.services(1)
@@ -458,13 +458,13 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it('Alice can update her service data', async function() {
+    it('Alice can update her service data', async function () {
       await serviceRegistry.connect(alice).updateServiceData(1, 'aliceUpdateHerFirstService')
       const serviceData = await serviceRegistry.services(1)
       expect(serviceData.serviceDataUri).to.be.equal('aliceUpdateHerFirstService')
     })
 
-    it('Bob can create his first proposal for an Open service n°1 from Alice', async function() {
+    it('Bob can create his first proposal for an Open service n°1 from Alice', async function () {
       // Proposal on the Open service n 1
       const bobTid = await talentLayerID.walletOfOwner(bob.address)
       const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
@@ -491,7 +491,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(proposalDataAfter.status.toString()).to.be.equal('0')
     })
 
-    it('Carol can create her first proposal (will be rejected by Alice) ', async function() {
+    it('Carol can create her first proposal (will be rejected by Alice) ', async function () {
       const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
       await serviceRegistry.connect(carol).createProposal(1, rateToken, 2, 'proposal1FromCarolToAlice1Service')
       await serviceRegistry.services(1)
@@ -500,7 +500,7 @@ describe('TalentLayer protocol global testing', function() {
       await serviceRegistry.getProposal(1, carolTid)
     })
 
-    it('Bob can update his first proposal ', async function() {
+    it('Bob can update his first proposal ', async function () {
       const bobTid = await talentLayerID.walletOfOwner(bob.address)
       const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
 
@@ -514,7 +514,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(proposalDataAfter.proposalDataUri).to.be.equal('updateProposal1FromBobToAlice1Service')
     })
 
-    it('Alice can validate Bob proposal', async function() {
+    it('Alice can validate Bob proposal', async function () {
       const bobTid = await talentLayerID.walletOfOwner(bob.address)
       const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
 
@@ -527,7 +527,7 @@ describe('TalentLayer protocol global testing', function() {
       expect(proposalDataAfter.status.toString()).to.be.equal('1')
     })
 
-    it('Alice can reject Carol proposal ', async function() {
+    it('Alice can reject Carol proposal ', async function () {
       const carolTid = await talentLayerID.walletOfOwner(carol.address)
       await serviceRegistry.connect(alice).rejectProposal(1, carolTid)
 
@@ -536,8 +536,8 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('Escrow Contract test.', function() {
-    describe('Successful use of Escrow for a service using an ERC20 token.', function() {
+  describe('Escrow Contract test.', function () {
+    describe('Successful use of Escrow for a service using an ERC20 token.', function () {
       const amountBob = 1000000
       const amountCarol = 2000
       const serviceId = 2
@@ -546,20 +546,20 @@ describe('TalentLayer protocol global testing', function() {
       let proposalIdCarol = 0 //Will be set later
       let totalAmount = 0 //Will be set later
 
-      it('Alice can NOT deposit tokens to escrow yet.', async function() {
+      it('Alice can NOT deposit tokens to escrow yet.', async function () {
         await token.connect(alice).approve(talentLayerEscrow.address, amountBob)
         await expect(talentLayerEscrow.connect(alice).createTokenTransaction('_metaEvidence', serviceId, proposalIdBob))
           .to.be.reverted
       })
 
-      it('Bob can make a second proposal on the Alice service n°2', async function() {
+      it('Bob can make a second proposal on the Alice service n°2', async function () {
         proposalIdBob = await talentLayerID.walletOfOwner(bob.address)
         await serviceRegistry
           .connect(bob)
           .createProposal(serviceId, token.address, amountBob, 'proposal2FromBobToAlice2Service')
       })
 
-      it('Carol can make her second proposal on the Alice service n°2', async function() {
+      it('Carol can make her second proposal on the Alice service n°2', async function () {
         proposalIdCarol = await talentLayerID.walletOfOwner(carol.address)
         await serviceRegistry
           .connect(carol)
@@ -593,7 +593,7 @@ describe('TalentLayer protocol global testing', function() {
         expect(originPlatformEscrowFeeRate).to.equal(1400)
       })
 
-      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function() {
+      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function () {
         const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
         await talentLayerPlatformID.connect(alice).updatePlatformEscrowFeeRate(aliceUserId, 1100)
         const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
@@ -621,30 +621,30 @@ describe('TalentLayer protocol global testing', function() {
           .withArgs(serviceId, proposalIdBob, transactionId)
       })
 
-      it('The deposit should also validate the proposal.', async function() {
+      it('The deposit should also validate the proposal.', async function () {
         const proposal = await serviceRegistry.getProposal(serviceId, proposalIdBob)
         await expect(proposal.status.toString()).to.be.equal('1')
       })
 
-      it('The deposit should also update the service with transactionId, proposalId, and status.', async function() {
+      it('The deposit should also update the service with transactionId, proposalId, and status.', async function () {
         const service = await serviceRegistry.getService(serviceId)
         await expect(service.status.toString()).to.be.equal('1')
         await expect(service.transactionId.toString()).to.be.equal('0')
         await expect(service.sellerId.toString()).to.be.equal(proposalIdBob)
       })
 
-      it("Alice can NOT deposit funds for Carol's proposal.", async function() {
+      it("Alice can NOT deposit funds for Carol's proposal.", async function () {
         await token.connect(alice).approve(talentLayerEscrow.address, amountCarol)
         await expect(
           talentLayerEscrow.connect(alice).createTokenTransaction('_metaEvidence', serviceId, proposalIdCarol),
         ).to.be.reverted
       })
 
-      it('Carol should not be allowed to release escrow the service.', async function() {
+      it('Carol should not be allowed to release escrow the service.', async function () {
         await expect(talentLayerEscrow.connect(carol).release(transactionId, 10)).to.be.revertedWith('Access denied.')
       })
 
-      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function() {
+      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -669,7 +669,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function() {
+      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -695,19 +695,19 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Carol can NOT reimburse alice.', async function() {
+      it('Carol can NOT reimburse alice.', async function () {
         await expect(talentLayerEscrow.connect(carol).reimburse(transactionId, totalAmount / 4)).to.revertedWith(
           'Access denied.',
         )
       })
 
-      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function() {
+      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function () {
         await expect(talentLayerEscrow.connect(bob).reimburse(transactionId, totalAmount)).to.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function() {
+      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function () {
         const transaction = await talentLayerEscrow.connect(bob).reimburse(transactionId, amountBob / 4)
         /* When asking for the reimbursement of a fee-less amount,
          * we expect the amount reimbursed to include all fees (calculated by the function,
@@ -718,18 +718,16 @@ describe('TalentLayer protocol global testing', function() {
           [talentLayerEscrow.address, alice, bob],
           [-totalAmount / 4, totalAmount / 4, 0],
         )
-        await expect(transaction)
-          .to.emit(talentLayerEscrow, 'PaymentCompleted')
-          .withArgs(serviceId)
+        await expect(transaction).to.emit(talentLayerEscrow, 'PaymentCompleted').withArgs(serviceId)
       })
 
-      it('Alice can not release escrow because there is none left. ', async function() {
+      it('Alice can not release escrow because there is none left. ', async function () {
         await expect(talentLayerEscrow.connect(alice).release(transactionId, 1)).to.be.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Alice can claim her token balance.', async function() {
+      it('Alice can claim her token balance.', async function () {
         const platformBalance = await talentLayerEscrow.connect(alice).getClaimableFeeBalance(token.address)
         const transaction = await talentLayerEscrow.connect(alice).claim(platformId, token.address)
         await expect(transaction).to.changeTokenBalances(
@@ -739,7 +737,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('The protocol owner can claim his token balance.', async function() {
+      it('The protocol owner can claim his token balance.', async function () {
         let protocolOwnerBalance = await talentLayerEscrow.connect(deployer).getClaimableFeeBalance(token.address)
         // await talentLayerEscrow.updateProtocolWallet(alice.address);
         const transaction = await talentLayerEscrow.connect(deployer).claim(0, token.address)
@@ -751,7 +749,7 @@ describe('TalentLayer protocol global testing', function() {
       })
     })
 
-    describe('Successful use of Escrow for a service using ETH.', function() {
+    describe('Successful use of Escrow for a service using ETH.', function () {
       const amountBob = 1000000
       const amountCarol = 200
       const serviceId = 3
@@ -761,7 +759,7 @@ describe('TalentLayer protocol global testing', function() {
       let totalAmount = 0 //Will be set later
       const ethAddress = '0x0000000000000000000000000000000000000000'
 
-      it('Alice can NOT deposit eth to escrow yet.', async function() {
+      it('Alice can NOT deposit eth to escrow yet.', async function () {
         const aliceUserId = await talentLayerPlatformID.getPlatformIdFromAddress(alice.address)
         await talentLayerPlatformID.connect(alice).updatePlatformEscrowFeeRate(aliceUserId, 1100)
         const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
@@ -778,21 +776,21 @@ describe('TalentLayer protocol global testing', function() {
           .to.be.reverted
       })
 
-      it('Bob can register a proposal.', async function() {
+      it('Bob can register a proposal.', async function () {
         proposalIdBob = await talentLayerID.walletOfOwner(bob.address)
         await serviceRegistry
           .connect(bob)
           .createProposal(serviceId, ethAddress, amountBob, 'proposal3FromBobToAlice3Service')
       })
 
-      it('Carol can register a proposal.', async function() {
+      it('Carol can register a proposal.', async function () {
         proposalIdCarol = await talentLayerID.walletOfOwner(carol.address)
         await serviceRegistry
           .connect(carol)
           .createProposal(serviceId, ethAddress, amountCarol, 'proposal3FromCarolToAlice3Service')
       })
 
-      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function() {
+      it("Alice can deposit funds for Bob's proposal, which will emit an event.", async function () {
         const transaction = await talentLayerEscrow
           .connect(alice)
           .createETHTransaction('_metaEvidence', serviceId, proposalIdBob, { value: totalAmount })
@@ -806,19 +804,19 @@ describe('TalentLayer protocol global testing', function() {
           .withArgs(serviceId, proposalIdBob, transactionId)
       })
 
-      it('The deposit should also validate the proposal.', async function() {
+      it('The deposit should also validate the proposal.', async function () {
         const proposal = await serviceRegistry.getProposal(serviceId, proposalIdBob)
         await expect(proposal.status.toString()).to.be.equal('1')
       })
 
-      it('The deposit should also update the service with transactionId, proposalId, and status.', async function() {
+      it('The deposit should also update the service with transactionId, proposalId, and status.', async function () {
         const service = await serviceRegistry.getService(serviceId)
         await expect(service.status.toString()).to.be.equal('1')
         await expect(service.transactionId).to.be.equal(transactionId)
         await expect(service.sellerId).to.be.equal(proposalIdBob)
       })
 
-      it("Alice can NOT deposit funds for Carol's proposal, and NO event should emit.", async function() {
+      it("Alice can NOT deposit funds for Carol's proposal, and NO event should emit.", async function () {
         await token.connect(alice).approve(talentLayerEscrow.address, amountCarol)
         await expect(
           talentLayerEscrow
@@ -827,11 +825,11 @@ describe('TalentLayer protocol global testing', function() {
         ).to.be.reverted
       })
 
-      it('Carol should not be allowed to release escrow the service.', async function() {
+      it('Carol should not be allowed to release escrow the service.', async function () {
         await expect(talentLayerEscrow.connect(carol).release(transactionId, 10)).to.be.revertedWith('Access denied.')
       })
 
-      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function() {
+      it('Alice can release half of the escrow to bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -856,7 +854,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function() {
+      it('Alice can release a quarter of the escrow to Bob, and fees are correctly split.', async function () {
         const transactionDetails = await talentLayerEscrow
           .connect(alice)
           .getTransactionDetails(transactionId.toString())
@@ -880,19 +878,19 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('Carol can NOT reimburse alice.', async function() {
+      it('Carol can NOT reimburse alice.', async function () {
         await expect(talentLayerEscrow.connect(carol).reimburse(transactionId, totalAmount / 4)).to.revertedWith(
           'Access denied.',
         )
       })
 
-      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function() {
+      it('Bob can NOT reimburse alice for more than what is left in escrow.', async function () {
         await expect(talentLayerEscrow.connect(bob).reimburse(transactionId, totalAmount)).to.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function() {
+      it('Bob can reimburse alice for what is left in the escrow, an emit will be sent.', async function () {
         const transaction = await talentLayerEscrow.connect(bob).reimburse(transactionId, amountBob / 4)
         /* When asking for the reimbursement of a fee-less amount,
          * we expect the amount reimbursed to include all fees (calculated by the function,
@@ -902,18 +900,16 @@ describe('TalentLayer protocol global testing', function() {
           [talentLayerEscrow.address, alice, bob],
           [-totalAmount / 4, totalAmount / 4, 0],
         )
-        await expect(transaction)
-          .to.emit(talentLayerEscrow, 'PaymentCompleted')
-          .withArgs(serviceId)
+        await expect(transaction).to.emit(talentLayerEscrow, 'PaymentCompleted').withArgs(serviceId)
       })
 
-      it('Alice can not release escrow because there is none left.', async function() {
+      it('Alice can not release escrow because there is none left.', async function () {
         await expect(talentLayerEscrow.connect(alice).release(transactionId, 10)).to.be.revertedWith(
           'Insufficient funds.',
         )
       })
 
-      it('Alice can claim her ETH balance.', async function() {
+      it('Alice can claim her ETH balance.', async function () {
         const platformEthBalance = await talentLayerEscrow.connect(alice).getClaimableFeeBalance(ethAddress)
         const transaction = await talentLayerEscrow.connect(alice).claim(platformId, ethAddress)
         await expect(transaction).to.changeEtherBalances(
@@ -922,7 +918,7 @@ describe('TalentLayer protocol global testing', function() {
         )
       })
 
-      it('The Protocol owner can claim his ETH balance.', async function() {
+      it('The Protocol owner can claim his ETH balance.', async function () {
         const protocolEthBalance = await talentLayerEscrow.connect(deployer).getClaimableFeeBalance(ethAddress)
         const transaction = await talentLayerEscrow.connect(deployer).claim(0, ethAddress)
         await expect(transaction).to.changeEtherBalances(
@@ -955,7 +951,7 @@ describe('TalentLayer protocol global testing', function() {
       )
     })
 
-    it('Alice and Bob can write a review now and we can get review data', async function() {
+    it('Alice and Bob can write a review now and we can get review data', async function () {
       await talentLayerReview.connect(alice).addReview(2, 'cidReview1', 2, 1)
       await talentLayerReview.connect(bob).addReview(2, 'cidReview2', 4, 1)
 
@@ -969,8 +965,8 @@ describe('TalentLayer protocol global testing', function() {
     })
   })
 
-  describe('Talent Layer Arbitrator contract test', function() {
-    it('the owner of the platform can update the arbitration price', async function() {
+  describe('Talent Layer Arbitrator contract test', function () {
+    it('the owner of the platform can update the arbitration price', async function () {
       const newArbitrationPrice = 1000
       const platformId = 1
 

--- a/test/utils/deploy.ts
+++ b/test/utils/deploy.ts
@@ -1,8 +1,8 @@
 import { ethers, upgrades } from 'hardhat'
 import {
-  ERC20,
   MockProofOfHumanity,
   ServiceRegistry,
+  SimpleERC20,
   TalentLayerArbitrator,
   TalentLayerEscrow,
   TalentLayerID,
@@ -25,7 +25,7 @@ export async function deploy(
     ServiceRegistry,
     TalentLayerReview,
     MockProofOfHumanity,
-    ERC20,
+    SimpleERC20,
   ]
 > {
   // Deploy MockProofOfHumanity


### PR DESCRIPTION
# New PR: Fix contracts typing in test

## Useful info

- Description: Fixes the typing of contract instances in a test file. They were typed as a general `Contract` instead of using the types generated by `typechain`. This was leading to not having no autocomplete and type checking when calling functions on those contracts.A

## Auto-Review checklist

- [X] Check if there is no merge conflict
- [X] If you have new .env variable, check if you add it in the .env.example file


## Typing

- [X] Check solhint feedbacks: `npm run solhint`
