### PR TITLE
Support delegation in service cancellation

### DIFF
--- a/contracts/TalentLayerService.sol
+++ b/contracts/TalentLayerService.sol
@@ -388,12 +388,13 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
 
     /**
      * Cancel a Service
+     * @param _tokenId The talentLayerId of the user
      * @param _serviceId, Service ID to cancel
      */
-    function cancelService(uint256 _serviceId) public {
+    function cancelService(uint256 _tokenId, uint256 _serviceId) public onlyOwnerOrDelegate(_tokenId) {
         Service storage service = services[_serviceId];
 
-        require(service.ownerId == tlId.ids(msg.sender), "Only the owner can cancel the service");
+        require(service.ownerId == _tokenId, "Only the owner can cancel the service");
         require(service.status == Status.Opened, "Only services with the open status can be cancelled");
         service.status = Status.Cancelled;
 

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -566,13 +566,13 @@ describe('TalentLayer protocol global testing', function () {
     })
 
     it('Alice can cancel her own service', async function () {
-      await talentLayerService.connect(alice).cancelService(5)
+      await talentLayerService.connect(alice).cancelService(aliceTlId, 5)
       const serviceData = await talentLayerService.services(5)
       expect(serviceData.status).to.be.equal(3)
     })
 
     it('Alice can cancel only a service that is open', async function () {
-      expect(talentLayerService.connect(alice).cancelService(5)).to.be.revertedWith(
+      expect(talentLayerService.connect(alice).cancelService(aliceTlId, 5)).to.be.revertedWith(
         'Only services with the open status can be cancelled',
       )
     })
@@ -588,7 +588,7 @@ describe('TalentLayer protocol global testing', function () {
     })
 
     it("Bob cannot cancel Alice's service", async function () {
-      expect(talentLayerService.connect(bob).cancelService(1)).to.be.revertedWith(
+      expect(talentLayerService.connect(bob).cancelService(aliceTlId, 1)).to.be.revertedWith(
         'Only the initiator can cancel the service',
       )
     })
@@ -944,7 +944,7 @@ describe('TalentLayer protocol global testing', function () {
             value: alicePlatformProposalPostingFee,
           })
         // Cancel the service
-        await talentLayerService.connect(alice).cancelService(serviceId)
+        await talentLayerService.connect(alice).cancelService(aliceTlId, serviceId)
         // Try to deposit fund to validate the proposal
         const transactionDetails = await talentLayerEscrow
           .connect(alice)


### PR DESCRIPTION
# New PR: Support delegation in service cancellation

## Useful info

- Description: Allow the `cancelService` function to be called by the user delegates.

## Auto-Review checklist

- [X] Check if there is no merge conflict
- [X] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [X] Check solhint feedbacks: `npm run solhint`
