### PR TITLE
Check only owner can update service data

### DIFF
--- a/contracts/TalentLayerService.sol
+++ b/contracts/TalentLayerService.sol
@@ -377,7 +377,8 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
         string calldata _dataUri
     ) public onlyOwnerOrDelegate(_profileId) {
         Service storage service = services[_serviceId];
-        require(_serviceId < nextServiceId, "This service doesn't exist");
+
+        require(service.ownerId == _profileId, "Only the owner can update the service");
         require(
             service.status == Status.Opened || service.status == Status.Filled,
             "Service status should be opened or filled"


### PR DESCRIPTION
# New PR: Check only owner can update service data

## Useful info

- Description: Adds a check that had been removed by mistake, to ensure only the owner of a service can update its data. The check on whether the involved service exists or not has been removed since this edge case is covered by the new require statement.

## Auto-Review checklist

- [X] Check if there is no merge conflict
- [X] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [X] Check solhint feedbacks: `npm run solhint`
