### PR TITLE
Block all ERC721 transfer functions

### DIFF
--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -289,20 +289,25 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     // =========================== Overrides ==============================
 
     /**
-     * @dev Blocks the transferFrom function
-     * @param from The address to transfer from
-     * @param to The address to transfer to
-     * @param tokenId The token ID to transfer
+     * @dev Override to prevent token transfer.
      */
-    function transferFrom(address from, address to, uint256 tokenId) public virtual override(ERC721Upgradeable) {}
+    function transferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
+    }
 
     /**
-     * @dev Blocks the safeTransferFrom function
-     * @param from The address to transfer from
-     * @param to The address to transfer to
-     * @param tokenId The token ID to transfer
+     * @dev Override to prevent token transfer.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId) public virtual override(ERC721Upgradeable) {}
+    function safeTransferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
+    }
+
+    /**
+     * @dev Override to prevent token transfer.
+     */
+    function safeTransferFrom(address, address, uint256, bytes memory) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
+    }
 
     /**
      * @dev Blocks the burn function

--- a/contracts/TalentLayerPlatformID.sol
+++ b/contracts/TalentLayerPlatformID.sol
@@ -468,23 +468,22 @@ contract TalentLayerPlatformID is ERC721Upgradeable, AccessControlUpgradeable, U
     /**
      * @dev Override to prevent token transfer.
      */
-    function transferFrom(
-        address /*from*/,
-        address /*to*/,
-        uint256 /*tokenId*/
-    ) public virtual override(ERC721Upgradeable) {
-        revert("Not allowed");
+    function transferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
     }
 
     /**
      * @dev Override to prevent token transfer.
      */
-    function safeTransferFrom(
-        address /*from*/,
-        address /*to*/,
-        uint256 /*tokenId*/
-    ) public virtual override(ERC721Upgradeable) {
-        revert("Not allowed");
+    function safeTransferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
+    }
+
+    /**
+     * @dev Override to prevent token transfer.
+     */
+    function safeTransferFrom(address, address, uint256, bytes memory) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
     }
 
     /**

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -271,20 +271,38 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     // =========================== Overrides ==============================
 
     /**
-     * @dev Blocks the transferFrom function
-     * @param from The address to transfer from
-     * @param to The address to transfer to
-     * @param tokenId The token ID to transfer
+     * @dev Override to prevent token transfer.
      */
-    function transferFrom(address from, address to, uint256 tokenId) public virtual override(ERC721Upgradeable) {}
+    function transferFrom(
+        address /*from*/,
+        address /*to*/,
+        uint256 /*tokenId*/
+    ) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
+    }
 
     /**
-     * @dev Blocks the safeTransferFrom function
-     * @param from The address to transfer from
-     * @param to The address to transfer to
-     * @param tokenId The token ID to transfer
+     * @dev Override to prevent token transfer.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId) public virtual override(ERC721Upgradeable) {}
+    function safeTransferFrom(
+        address /*from*/,
+        address /*to*/,
+        uint256 /*tokenId*/
+    ) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
+    }
+
+    /**
+     * @dev Override to prevent token transfer.
+     */
+    function safeTransferFrom(
+        address /*from*/,
+        address /*to*/,
+        uint256 /*tokenId*/,
+        bytes memory /*data*/
+    ) public virtual override(ERC721Upgradeable) {
+        revert("Token transfer is not allowed");
+    }
 
     /**
      * @dev Blocks the burn function

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -125,8 +125,20 @@ describe('TalentLayer protocol global testing', function () {
 
     it('Alice should not be able to transfer her PlatformId Id to Bob', async function () {
       await expect(
-        talentLayerPlatformID.transferFrom(alice.address, bob.address, 1),
-      ).to.be.revertedWith('Not allowed')
+        talentLayerPlatformID.connect(alice).transferFrom(alice.address, bob.address, 1),
+      ).to.be.revertedWith('Token transfer is not allowed')
+
+      await expect(
+        talentLayerPlatformID
+          .connect(alice)
+          ['safeTransferFrom(address,address,uint256)'](alice.address, bob.address, 1),
+      ).to.be.revertedWith('Token transfer is not allowed')
+
+      await expect(
+        talentLayerPlatformID
+          .connect(alice)
+          ['safeTransferFrom(address,address,uint256,bytes)'](alice.address, bob.address, 1, []),
+      ).to.be.revertedWith('Token transfer is not allowed')
     })
 
     it('Alice should not be able to mint a new PlatformId ID', async function () {
@@ -419,6 +431,24 @@ describe('TalentLayer protocol global testing', function () {
       const carolUserId = await talentLayerID.ids(carol.address)
       const profileData = await talentLayerID.profiles(carolUserId)
       expect(profileData.platformId).to.be.equal('1')
+    })
+
+    it('Alice should not be able to transfer her talentLayerId to Bob', async function () {
+      await expect(
+        talentLayerID.connect(alice).transferFrom(alice.address, bob.address, 1),
+      ).to.be.revertedWith('Token transfer is not allowed')
+
+      await expect(
+        talentLayerID
+          .connect(alice)
+          ['safeTransferFrom(address,address,uint256)'](alice.address, bob.address, 1),
+      ).to.be.revertedWith('Token transfer is not allowed')
+
+      await expect(
+        talentLayerID
+          .connect(alice)
+          ['safeTransferFrom(address,address,uint256,bytes)'](alice.address, bob.address, 1, []),
+      ).to.be.revertedWith('Token transfer is not allowed')
     })
 
     it('The deployer can update the mint fee', async function () {


### PR DESCRIPTION
# New PR: Block all ERC721 transfer functions

## Useful info

- Description: Fixes an issue in `TalentLayerID` and `TalentLayerPlatformID`, where the version of `safeTransferFrom` function with a 4th parameter (part of ERC721 standard) was not being overridden, making it possible to transfer the NFTs using this function.

## Auto-Review checklist

- [X] Check if there is no merge conflict
- [X] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [X] Check solhint feedbacks: `npm run solhint`
