### PR TITLE
Security audit remove sender param

### DIFF
--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -380,7 +380,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
     // =========================== Owner functions ==============================
 
     /**
-     * @notice Updated the Protocol Fee
+     * @notice Updates the Protocol Fee
      * @dev Only the owner can call this function
      * @param _protocolEscrowFeeRate The new protocol fee
      */
@@ -390,7 +390,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
     }
 
     /**
-     * @notice Updated the Protocol wallet
+     * @notice Updates the Protocol wallet
      * @dev Only the owner can call this function
      * @param _protocolWallet The new wallet address
      */
@@ -535,7 +535,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
                 arbitrationFeeTimeout: originServiceCreationPlatform.arbitrationFeeTimeout
             })
         );
-        _deposit(sender, proposal.rateToken, transactionAmount);
+        _deposit(proposal.rateToken, transactionAmount);
         talentLayerServiceContract.afterDeposit(_serviceId, _proposalId, transactionId);
         _afterCreateTransaction(service.ownerId, proposal.ownerId, transactionId, _metaEvidence);
 
@@ -924,12 +924,11 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
 
     /**
      * @notice Used to transfer ERC20 tokens balance from a wallet to the escrow contract's wallet.
-     * @param _sender The wallet to transfer the tokens from
      * @param _token The token to transfer
      * @param _amount The amount of tokens to transfer
      */
-    function _deposit(address _sender, address _token, uint256 _amount) private {
-        require(IERC20(_token).transferFrom(_sender, address(this), _amount), "Transfer must not fail");
+    function _deposit(address _token, uint256 _amount) private {
+        require(IERC20(_token).transferFrom(_msgSender(), address(this), _amount), "Transfer must not fail");
     }
 
     /**

--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -535,7 +535,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
                 arbitrationFeeTimeout: originServiceCreationPlatform.arbitrationFeeTimeout
             })
         );
-        _deposit(proposal.rateToken, transactionAmount);
+        require(IERC20(proposal.rateToken).transferFrom(_msgSender(), address(this), transactionAmount), "Transfer must not fail");
         talentLayerServiceContract.afterDeposit(_serviceId, _proposalId, transactionId);
         _afterCreateTransaction(service.ownerId, proposal.ownerId, transactionId, _metaEvidence);
 
@@ -920,15 +920,6 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
             transaction.arbitrationFeeTimeout
         );
         emit MetaEvidence(_transactionId, _metaEvidence);
-    }
-
-    /**
-     * @notice Used to transfer ERC20 tokens balance from a wallet to the escrow contract's wallet.
-     * @param _token The token to transfer
-     * @param _amount The amount of tokens to transfer
-     */
-    function _deposit(address _token, uint256 _amount) private {
-        require(IERC20(_token).transferFrom(_msgSender(), address(this), _amount), "Transfer must not fail");
     }
 
     /**

--- a/contracts/TalentLayerService.sol
+++ b/contracts/TalentLayerService.sol
@@ -347,7 +347,6 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
         Proposal storage proposal = proposals[_serviceId][_proposalId];
 
         service.status = Status.Confirmed;
-        //TODO confusing, should be _proposalId
         service.acceptedProposalId = proposal.ownerId;
         service.transactionId = _transactionId;
         proposal.status = ProposalStatus.Validated;

--- a/contracts/TalentLayerService.sol
+++ b/contracts/TalentLayerService.sol
@@ -347,6 +347,7 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
         Proposal storage proposal = proposals[_serviceId][_proposalId];
 
         service.status = Status.Confirmed;
+        //TODO confusing, should be _proposalId
         service.acceptedProposalId = proposal.ownerId;
         service.transactionId = _transactionId;
         proposal.status = ProposalStatus.Validated;


### PR DESCRIPTION
# New PR:

## Useful info

- Trello: NA
- Description: The _deposit function triggers a transfer which should always come  from the msg.sender. Therefore, there is no need to give a parameter for a sender.

Moreover, the Escrow contract has some token spending allowance for many addresses, there is a potential risk of wild transfer if in a future upgrade of the escrow contract, the _deposit function is used elsewhere without propper checks

## Auto-Review checklist

- [ ] Check if there is no merge conflict
- [ ] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [ ] Check solhint feedbacks: `npm run solhint`
