### PR TITLE
Audit escrow - Factorized and optimized release & reimburse functions

### DIFF
--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -493,15 +493,12 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         uint256 _transactionId,
         uint256 _amount
     ) external onlyOwnerOrDelegate(_profileId) {
-        Transaction storage transaction = transactions[_transactionId];
-        require(_amount >= FEE_DIVIDER || (_amount < FEE_DIVIDER && _amount == transaction.amount), "Amount too low");
-        require(transactions.length > _transactionId, "Not a valid transaction id");
-        require(transaction.sender == talentLayerIdContract.ownerOf(_profileId), "Access denied");
-        require(transaction.status == Status.NoDispute, "The transaction shouldn't be disputed");
-        require(transaction.amount >= _amount, "Insufficient funds");
+        _validatePayment(_transactionId, PaymentType.Release, _profileId, _amount);
 
+        Transaction storage transaction = transactions[_transactionId];
         transaction.amount -= _amount;
-        _release(transaction, _amount);
+
+        _release(_transactionId, _amount);
     }
 
     /**
@@ -516,15 +513,12 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         uint256 _transactionId,
         uint256 _amount
     ) external onlyOwnerOrDelegate(_profileId) {
-        Transaction storage transaction = transactions[_transactionId];
-        require(_amount >= FEE_DIVIDER || (_amount < FEE_DIVIDER && _amount == transaction.amount), "Amount too low");
-        require(transactions.length > _transactionId, "Not a valid transaction id");
-        require(transaction.receiver == talentLayerIdContract.ownerOf(_profileId), "Access denied");
-        require(transaction.status == Status.NoDispute, "The transaction shouldn't be disputed");
-        require(transaction.amount >= _amount, "Insufficient funds");
+        _validatePayment(_transactionId, PaymentType.Reimburse, _profileId, _amount);
 
+        Transaction storage transaction = transactions[_transactionId];
         transaction.amount -= _amount;
-        _reimburse(transaction, _amount);
+
+        _reimburse(_transactionId, _amount);
     }
 
     /**
@@ -800,17 +794,17 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         // Send the funds to the winner and reimburse the arbitration fee.
         if (_ruling == SENDER_WINS) {
             sender.call{value: senderFee}("");
-            _reimburse(transaction, amount);
+            _reimburse(_transactionId, amount);
         } else if (_ruling == RECEIVER_WINS) {
             receiver.call{value: receiverFee}("");
-            _release(transaction, amount);
+            _release(_transactionId, amount);
         } else {
             // If no ruling is given split funds in half
             uint256 splitFeeAmount = senderFee / 2;
             uint256 splitTransactionAmount = amount / 2;
 
-            _reimburse(transaction, splitTransactionAmount);
-            _release(transaction, splitTransactionAmount);
+            _reimburse(_transactionId, splitTransactionAmount);
+            _release(_transactionId, splitTransactionAmount);
 
             sender.call{value: splitFeeAmount}("");
             receiver.call{value: splitFeeAmount}("");
@@ -872,83 +866,117 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
     }
 
     /**
-     * @notice Used to release part of the escrow payment to the seller.
+     * @notice Used to release part of the escrow payment to the receiver.
      * @dev The release of an amount will also trigger the release of the fees to the platform's balances & the protocol fees.
-     * @param _transaction The transaction to release the escrow value for
-     * @param _releaseAmount The amount to release
+     * @param _transactionId The transaction to release the escrow value for
+     * @param _amount The amount to release
      */
-    function _release(Transaction memory _transaction, uint256 _releaseAmount) private {
+    function _release(uint256 _transactionId, uint256 _amount) private {
+        _distributeFees(_transactionId, _amount);
+
+        Transaction storage transaction = transactions[_transactionId];
+        _safeTransferBalance(payable(transaction.receiver), transaction.token, _amount);
+
+        _afterPayment(_transactionId, PaymentType.Release, _amount);
+    }
+
+    /**
+     * @notice Used to reimburse part of the escrow payment to the sender.
+     * @dev Fees linked to the amount reimbursed will be automatically calculated and send back to the sender in the same transfer
+     * @param _transactionId The transaction
+     * @param _amount The amount to reimburse without fees
+     */
+    function _reimburse(uint256 _transactionId, uint256 _amount) private {
+        Transaction storage transaction = transactions[_transactionId];
+        uint256 totalReleaseAmount = _calculateTotalWithFees(
+            _amount,
+            transaction.originServiceFeeRate,
+            transaction.originValidatedProposalFeeRate
+        );
+        _safeTransferBalance(payable(transaction.sender), transaction.token, totalReleaseAmount);
+
+        _afterPayment(_transactionId, PaymentType.Reimburse, _amount);
+    }
+
+    /**
+     * @notice Distribute fees to the platform's balances & the protocol after a fund release
+     * @param _transactionId The transaction linked to the payment
+     * @param _releaseAmount The amount released
+     */
+    function _distributeFees(uint256 _transactionId, uint256 _releaseAmount) private {
+        Transaction storage transaction = transactions[_transactionId];
+
         uint256 originServiceCreationPlatformId = talentLayerServiceContract
-            .getService(_transaction.serviceId)
+            .getService(transaction.serviceId)
             .platformId;
         uint256 originValidatedProposalPlatformId = talentLayerServiceContract
-            .getProposal(_transaction.serviceId, _transaction.proposalId)
+            .getProposal(transaction.serviceId, transaction.proposalId)
             .platformId;
-        uint256 protocolEscrowFeeRateAmount = (_transaction.protocolEscrowFeeRate * _releaseAmount) / FEE_DIVIDER;
-        uint256 originServiceFeeRate = (_transaction.originServiceFeeRate * _releaseAmount) / FEE_DIVIDER;
-        uint256 originValidatedProposalFeeRate = (_transaction.originValidatedProposalFeeRate * _releaseAmount) /
+
+        uint256 protocolEscrowFeeRateAmount = (transaction.protocolEscrowFeeRate * _releaseAmount) / FEE_DIVIDER;
+        uint256 originServiceFeeRate = (transaction.originServiceFeeRate * _releaseAmount) / FEE_DIVIDER;
+        uint256 originValidatedProposalFeeRate = (transaction.originValidatedProposalFeeRate * _releaseAmount) /
             FEE_DIVIDER;
 
-        platformIdToTokenToBalance[PROTOCOL_INDEX][_transaction.token] += protocolEscrowFeeRateAmount;
-        platformIdToTokenToBalance[originServiceCreationPlatformId][_transaction.token] += originServiceFeeRate;
+        platformIdToTokenToBalance[PROTOCOL_INDEX][transaction.token] += protocolEscrowFeeRateAmount;
+        platformIdToTokenToBalance[originServiceCreationPlatformId][transaction.token] += originServiceFeeRate;
         platformIdToTokenToBalance[originValidatedProposalPlatformId][
-            _transaction.token
+            transaction.token
         ] += originValidatedProposalFeeRate;
-
-        _safeTransferBalance(payable(_transaction.receiver), _transaction.token, _releaseAmount);
 
         emit OriginServiceFeeRateReleased(
             originServiceCreationPlatformId,
-            _transaction.serviceId,
-            _transaction.token,
+            transaction.serviceId,
+            transaction.token,
             originServiceFeeRate
         );
         emit OriginValidatedProposalFeeRateReleased(
             originValidatedProposalPlatformId,
-            _transaction.serviceId,
-            _transaction.token,
+            transaction.serviceId,
+            transaction.token,
             originServiceFeeRate
         );
-        emit Payment(_transaction.id, PaymentType.Release, _transaction.token, _releaseAmount, _transaction.serviceId);
-
-        _distributeMessage(_transaction.serviceId, _transaction.amount);
     }
 
     /**
-     * @notice Used to reimburse part of the escrow payment to the buyer.
-     * @dev If token payment, need token approval for the transfer of _releaseAmount before executing this function.
-     *      The amount reimbursed must not include the fees, they will be automatically calculated and reimbursed to the buyer.
-     * @param _transaction The transaction
-     * @param _releaseAmount The amount to reimburse without fees
+     * @notice Used to validate a realease or a reimburse payment
+     * @param _transactionId The transaction linked to the payment
+     * @param _paymentType The type of payment to validate
+     * @param _profileId The profileId of the msgSender
+     * @param _amount The amount to release
      */
-    function _reimburse(Transaction memory _transaction, uint256 _releaseAmount) private {
-        uint256 totalReleaseAmount = _calculateTotalWithFees(
-            _releaseAmount,
-            _transaction.originServiceFeeRate,
-            _transaction.originValidatedProposalFeeRate
-        );
-        _safeTransferBalance(payable(_transaction.sender), _transaction.token, totalReleaseAmount);
+    function _validatePayment(
+        uint256 _transactionId,
+        PaymentType _paymentType,
+        uint256 _profileId,
+        uint256 _amount
+    ) private view {
+        Transaction storage _transaction = transactions[_transactionId];
+        if (_paymentType == PaymentType.Release) {
+            require(_transaction.sender == talentLayerIdContract.ownerOf(_profileId), "Access denied");
+        } else if (_paymentType == PaymentType.Reimburse) {
+            require(_transaction.receiver == talentLayerIdContract.ownerOf(_profileId), "Access denied");
+        }
 
-        emit Payment(
-            _transaction.id,
-            PaymentType.Reimburse,
-            _transaction.token,
-            _releaseAmount,
-            _transaction.serviceId
-        );
-
-        _distributeMessage(_transaction.serviceId, _transaction.amount);
+        require(transactions.length > _transaction.id, "Not a valid transaction id");
+        require(_transaction.status == Status.NoDispute, "The transaction shouldn't be disputed");
+        require(_transaction.amount >= _amount, "Insufficient funds");
+        require(_amount >= FEE_DIVIDER || (_amount < FEE_DIVIDER && _amount == _transaction.amount), "Amount too low");
     }
 
     /**
-     * @notice Used to trigger "afterFullPayment" function & emit "PaymentCompleted" event if applicable.
-     * @param _serviceId The id of the service
-     * @param _amount The amount of the transaction
+     * @notice Used to trigger events after a payment and to complete a service when the payment is full
+     * @param _transactionId The transaction linked to the payment
+     * @param _paymentType The type of the payment
+     * @param _releaseAmount The amount of the transaction
      */
-    function _distributeMessage(uint256 _serviceId, uint256 _amount) private {
-        if (_amount == 0) {
-            talentLayerServiceContract.afterFullPayment(_serviceId);
-            emit PaymentCompleted(_serviceId);
+    function _afterPayment(uint256 _transactionId, PaymentType _paymentType, uint256 _releaseAmount) private {
+        Transaction storage transaction = transactions[_transactionId];
+        emit Payment(transaction.id, _paymentType, transaction.token, _releaseAmount, transaction.serviceId);
+
+        if (transaction.amount == 0) {
+            talentLayerServiceContract.afterFullPayment(transaction.serviceId);
+            emit PaymentCompleted(transaction.serviceId);
         }
     }
 

--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -493,10 +493,9 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         uint256 _transactionId,
         uint256 _amount
     ) external onlyOwnerOrDelegate(_profileId) {
-        require(_amount >= FEE_DIVIDER, "Amount too low");
-        require(transactions.length > _transactionId, "Not a valid transaction id");
         Transaction storage transaction = transactions[_transactionId];
-
+        require(_amount >= FEE_DIVIDER || (_amount < FEE_DIVIDER && _amount == transaction.amount), "Amount too low");
+        require(transactions.length > _transactionId, "Not a valid transaction id");
         require(transaction.sender == talentLayerIdContract.ownerOf(_profileId), "Access denied");
         require(transaction.status == Status.NoDispute, "The transaction shouldn't be disputed");
         require(transaction.amount >= _amount, "Insufficient funds");
@@ -517,10 +516,9 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         uint256 _transactionId,
         uint256 _amount
     ) external onlyOwnerOrDelegate(_profileId) {
-        require(_amount >= FEE_DIVIDER, "Amount too low");
-        require(transactions.length > _transactionId, "Not a valid transaction id");
         Transaction storage transaction = transactions[_transactionId];
-
+        require(_amount >= FEE_DIVIDER || (_amount < FEE_DIVIDER && _amount == transaction.amount), "Amount too low");
+        require(transactions.length > _transactionId, "Not a valid transaction id");
         require(transaction.receiver == talentLayerIdContract.ownerOf(_profileId), "Access denied");
         require(transaction.status == Status.NoDispute, "The transaction shouldn't be disputed");
         require(transaction.amount >= _amount, "Insufficient funds");


### PR DESCRIPTION
The main optim is linked to EIP-2929, since it, the first SLOAD operation costs 2100 gas, but once that memory is read, it is cached and considered warm, which has a cost of 100 gas to load again. So in our case, it's way cheaper to load the transaction object from storage again rather than passing it through function and so in memory. As the transaction object is large, the impact is quite big

- Remove most of duplicate code between the two functions

- Contract size reduce, no more warning !
![image](https://user-images.githubusercontent.com/747152/220329999-4930464a-cd42-45ee-9da2-91be978d6d4f.png)

- Optim gas usage on execution, release -13K / reimburse -17K
![image](https://user-images.githubusercontent.com/747152/220330236-1b4a55f7-8d7f-4a43-b3e4-2b92c9bc228e.png)
![image](https://user-images.githubusercontent.com/747152/220330242-44c45a01-d3a5-4fc3-a7c3-17c63ad2016a.png)

- Optim gas deployment -40K