### PR TITLE
Time out function concat

### DIFF
--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -613,8 +613,6 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
             "Timeout time has not passed yet"
         );
 
-        uint256 receiverFee;
-
         // Reimburse sender if has paid any fees.
         if (transaction.senderFee != 0) {
             uint256 senderFee = transaction.senderFee;
@@ -623,11 +621,12 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
             _executeRuling(_transactionId, RECEIVER_WINS);
         }
         // Reimburse receiver if has paid any fees.
-        transaction.receiverFee != 0;
-        receiverFee = transaction.receiverFee;
-        transaction.receiverFee = 0;
-        payable(transaction.receiver).call{value: receiverFee}("");
-        _executeRuling(_transactionId, SENDER_WINS);
+        if (transaction.receiverFee != 0) {
+            uint256 receiverFee = transaction.receiverFee;
+            transaction.receiverFee = 0;
+            payable(transaction.receiver).call{value: receiverFee}("");
+            _executeRuling(_transactionId, SENDER_WINS);
+        }
     }
 
     /**

--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -605,18 +605,20 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
     function timeOutByReceiverOrSender(uint256 _transactionId) public {
         Transaction storage transaction = transactions[_transactionId];
         require(
+            transaction.status == Status.WaitingReceiver || transaction.status == Status.WaitingSender,
+            "The transaction is not waiting on the receiver or sender"
+        );
+        require(
             block.timestamp - transaction.lastInteraction >= transaction.arbitrationFeeTimeout,
             "Timeout time has not passed yet"
         );
 
         if (transaction.senderFee != 0) {
-            require(_msgSender() == transaction.sender, "The caller must be the sender");
             uint256 senderFee = transaction.senderFee;
             transaction.senderFee = 0;
             payable(transaction.sender).call{value: senderFee}("");
             _executeRuling(_transactionId, RECEIVER_WINS);
         } else if (transaction.receiverFee != 0) {
-            require(_msgSender() == transaction.receiver, "The caller must be the receiver");
             uint256 receiverFee = transaction.receiverFee;
             transaction.receiverFee = 0;
             payable(transaction.receiver).call{value: receiverFee}("");

--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -614,14 +614,13 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         );
 
         // Reimburse sender if has paid any fees.
+        // Reimburse receiver if has paid any fees
         if (transaction.senderFee != 0) {
             uint256 senderFee = transaction.senderFee;
             transaction.senderFee = 0;
             payable(transaction.sender).call{value: senderFee}("");
             _executeRuling(_transactionId, RECEIVER_WINS);
-        }
-        // Reimburse receiver if has paid any fees.
-        if (transaction.receiverFee != 0) {
+        } else if (transaction.receiverFee != 0) {
             uint256 receiverFee = transaction.receiverFee;
             transaction.receiverFee = 0;
             payable(transaction.receiver).call{value: receiverFee}("");

--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -594,7 +594,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
     }
 
     /**
-     * @notice Pays receiver if sender fails to pay the arbitration fee in time.
+     * @notice If one party fails to pay the arbitration fee in time, the other can call this function and will win the case
      * @param _transactionId Id of the transaction.
      */
     function arbitrationFeeTimeout(uint256 _transactionId) public {

--- a/test/batch/disputeResolution.ts
+++ b/test/batch/disputeResolution.ts
@@ -272,7 +272,7 @@ describe('Dispute Resolution, standard flow', function () {
 
   describe('Attempt to end dispute before arbitration fee timeout has passed', async function () {
     it('Fails if is not called by the sender of the transaction', async function () {
-      const tx = talentLayerEscrow.connect(alice).timeOutByReceiverOrSender(transactionId)
+      const tx = talentLayerEscrow.connect(alice).arbitrationFeeTimeout(transactionId)
       await expect(tx).to.be.revertedWith('Timeout time has not passed yet')
     })
   })
@@ -507,11 +507,18 @@ describe('Dispute Resolution, with party failing to pay arbitration fee on time'
     let tx: ContractTransaction
 
     before(async function () {
-      tx = await talentLayerEscrow.connect(alice).timeOutByReceiverOrSender(transactionId)
+      tx = await talentLayerEscrow.connect(alice).arbitrationFeeTimeout(transactionId)
+      // we check the transaction status
+      const transaction = await talentLayerEscrow
+        .connect(alice)
+        .getTransactionDetails(transactionId)
+      console.log('TITITITIT', transaction.status)
+      console.log('TOTOTOTOT', transaction.senderFee)
     })
 
     it('The sender wins the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function () {
       const sentAmount = totalTransactionAmount.add(arbitrationCost)
+
       await expect(tx).to.changeEtherBalances(
         [alice.address, talentLayerEscrow.address],
         [sentAmount, -sentAmount],

--- a/test/batch/disputeResolution.ts
+++ b/test/batch/disputeResolution.ts
@@ -272,7 +272,7 @@ describe('Dispute Resolution, standard flow', function () {
 
   describe('Attempt to end dispute before arbitration fee timeout has passed', async function () {
     it('Fails if is not called by the sender of the transaction', async function () {
-      const tx = talentLayerEscrow.connect(alice).timeOutBySender(transactionId)
+      const tx = talentLayerEscrow.connect(alice).timeOutByReceiverOrSender(transactionId)
       await expect(tx).to.be.revertedWith('Timeout time has not passed yet')
     })
   })
@@ -507,7 +507,7 @@ describe('Dispute Resolution, with party failing to pay arbitration fee on time'
     let tx: ContractTransaction
 
     before(async function () {
-      tx = await talentLayerEscrow.connect(alice).timeOutBySender(transactionId)
+      tx = await talentLayerEscrow.connect(alice).timeOutByReceiverOrSender(transactionId)
     })
 
     it('The sender wins the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function () {

--- a/test/batch/disputeResolution.ts
+++ b/test/batch/disputeResolution.ts
@@ -512,8 +512,6 @@ describe('Dispute Resolution, with party failing to pay arbitration fee on time'
       const transaction = await talentLayerEscrow
         .connect(alice)
         .getTransactionDetails(transactionId)
-      console.log('TITITITIT', transaction.status)
-      console.log('TOTOTOTOT', transaction.senderFee)
     })
 
     it('The sender wins the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function () {


### PR DESCRIPTION
# New PR:

## Useful info

- Concat timeOutBySender and timeOutByReceuver into one fct arbitrationFeeTimeout 
- Size : - 0.38 KB
- Deploy : - 80k
- Execution : + 150

## Auto-Review checklist

- [x] Check if there is no merge conflict
- [x] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [x] Check solhint feedbacks: `npm run solhint`
