### PR TITLE
Ipfs uri validation

### DIFF
--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -441,6 +441,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         require(proposal.ownerId == _proposalId, "Incorrect proposal ID");
         require(service.status == ITalentLayerService.Status.Opened, "Service status not open");
         require(proposal.status == ITalentLayerService.ProposalStatus.Pending, "Proposal status not pending");
+        require(bytes(_metaEvidence).length == 46, "Invalid cid");
         require(
             keccak256(abi.encodePacked(proposal.dataUri)) == keccak256(abi.encodePacked(_originDataUri)),
             "Proposal dataUri has changed"

--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -306,7 +306,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
     // =========================== Modifiers ==============================
 
     /**
-     * @notice Check if the given address is either the owner of the delegate of the given user
+     * @notice Check if the given address is either the owner or the delegate of the given user
      * @param _profileId The TalentLayer ID of the user
      */
     modifier onlyOwnerOrDelegate(uint256 _profileId) {
@@ -343,20 +343,19 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
     // =========================== View functions ==============================
 
     /**
-     * @dev Only the owner of the platform ID can execute this function
+     * @dev Only the owner of the platform ID or the owner can execute this function
      * @param _token Token address ("0" for ETH)
-     * @return balance The balance of the platform
+     * @return balance The balance of the platform or the protocol
      */
     function getClaimableFeeBalance(address _token) external view returns (uint256 balance) {
         address sender = _msgSender();
 
         if (owner() == sender) {
             return platformIdToTokenToBalance[PROTOCOL_INDEX][_token];
-        } else {
-            uint256 platformId = talentLayerPlatformIdContract.ids(sender);
-            talentLayerPlatformIdContract.isValid(platformId);
-            return platformIdToTokenToBalance[platformId][_token];
         }
+        uint256 platformId = talentLayerPlatformIdContract.ids(sender);
+        talentLayerPlatformIdContract.isValid(platformId);
+        return platformIdToTokenToBalance[platformId][_token];
     }
 
     /**
@@ -366,7 +365,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
      * @return transaction The transaction details
      */
     function getTransactionDetails(uint256 _transactionId) external view returns (Transaction memory) {
-        require(transactions.length > _transactionId, "Not a valid transaction id");
+        require(transactions.length > _transactionId, "Invalid transaction id");
         Transaction memory transaction = transactions[_transactionId];
 
         address sender = _msgSender();
@@ -952,7 +951,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
             require(_transaction.receiver == talentLayerIdContract.ownerOf(_profileId), "Access denied");
         }
 
-        require(transactions.length > _transaction.id, "Not a valid transaction id");
+        require(transactions.length > _transaction.id, "Invalid transaction id");
         require(_transaction.status == Status.NoDispute, "The transaction shouldn't be disputed");
         require(_transaction.amount >= _amount, "Insufficient funds");
         require(_amount >= FEE_DIVIDER || (_amount < FEE_DIVIDER && _amount == _transaction.amount), "Amount too low");

--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -223,7 +223,7 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
      * @param _newCid New IPFS URI
      */
     function updateProfileData(uint256 _profileId, string memory _newCid) public onlyOwnerOrDelegate(_profileId) {
-        require(bytes(_newCid).length > 0, "Should provide a valid IPFS URI");
+        require(bytes(_newCid).length == 46, "Invalid cid");
         profiles[_profileId].dataUri = _newCid;
 
         emit CidUpdated(_profileId, _newCid);

--- a/contracts/TalentLayerPlatformID.sol
+++ b/contracts/TalentLayerPlatformID.sol
@@ -251,7 +251,7 @@ contract TalentLayerPlatformID is ERC721Upgradeable, AccessControlUpgradeable, U
      */
     function updateProfileData(uint256 _platformId, string memory _newCid) public {
         require(ownerOf(_platformId) == msg.sender, "You're not the owner of this platform");
-        require(bytes(_newCid).length > 0, "Should provide a valid IPFS URI");
+        require(bytes(_newCid).length == 46, "Invalid cid");
 
         platforms[_platformId].dataUri = _newCid;
 

--- a/contracts/TalentLayerService.sol
+++ b/contracts/TalentLayerService.sol
@@ -237,7 +237,7 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
     ) public payable onlyOwnerOrDelegate(_profileId) returns (uint256) {
         uint256 servicePostingFee = talentLayerPlatformIdContract.getServicePostingFee(_platformId);
         require(msg.value == servicePostingFee, "Non-matching funds");
-        require(bytes(_dataUri).length > 0, "Should provide a valid IPFS URI");
+        require(bytes(_dataUri).length == 46, "Invalid cid");
 
         uint256 id = nextServiceId;
         nextServiceId++;
@@ -285,7 +285,7 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
         );
 
         require(service.ownerId != _profileId, "You couldn't create proposal for your own service");
-        require(bytes(_dataUri).length > 0, "Should provide a valid IPFS URI");
+        require(bytes(_dataUri).length == 46, "Invalid cid");
 
         proposals[_serviceId][_profileId] = Proposal({
             status: ProposalStatus.Pending,
@@ -332,7 +332,7 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
         Proposal storage proposal = proposals[_serviceId][_profileId];
         require(service.status == Status.Opened, "Service is not opened");
         require(proposal.ownerId == _profileId, "This proposal doesn't exist yet");
-        require(bytes(_dataUri).length > 0, "Should provide a valid IPFS URI");
+        require(bytes(_dataUri).length == 46, "Invalid cid");
         require(proposal.status != ProposalStatus.Validated, "This proposal is already updated");
         require(_rateAmount >= allowedTokenList[_rateToken].minimumTransactionAmount, "Amount is too low");
 
@@ -406,7 +406,7 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
         Service storage service = services[_serviceId];
         require(service.ownerId == _profileId, "Only the owner can update the service");
         require(service.status == Status.Opened, "Service status should be opened");
-        require(bytes(_dataUri).length > 0, "Should provide a valid IPFS URI");
+        require(bytes(_dataUri).length == 46, "Invalid cid");
 
         service.dataUri = _dataUri;
 

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -211,7 +211,7 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
      * @param _newCid New IPFS URI
      */
     function updateProfileData(uint256 _profileId, string memory _newCid) public onlyOwnerOrDelegate(_profileId) {
-        require(bytes(_newCid).length > 0, "Should provide a valid IPFS URI");
+        require(bytes(_newCid).length == 46, "Invalid cid");
         profiles[_profileId].dataUri = _newCid;
 
         emit CidUpdated(_profileId, _newCid);

--- a/scripts/playground/0-mint-platform-ID.ts
+++ b/scripts/playground/0-mint-platform-ID.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../.deployment/deploymentManager'
 import hre = require('hardhat')
+import { cid } from './constants'
 
 /*
 in this script we will mint a new platform ID for HireVibes
@@ -31,14 +32,14 @@ async function main() {
   await mint2.wait()
 
   const daveTalentLayerIdPlatform = await platformIdContract.ids(dave.address)
-  await platformIdContract.connect(dave).updateProfileData(daveTalentLayerIdPlatform, 'newCid')
+  await platformIdContract.connect(dave).updateProfileData(daveTalentLayerIdPlatform, cid)
   await platformIdContract.connect(dave).updateOriginServiceFeeRate(daveTalentLayerIdPlatform, 1000)
   await platformIdContract
     .connect(dave)
     .updateOriginValidatedProposalFeeRate(daveTalentLayerIdPlatform, 2500)
 
   const bobTalentLayerIdPlatform = await platformIdContract.ids(bob.address)
-  await platformIdContract.connect(bob).updateProfileData(bobTalentLayerIdPlatform, 'newCid')
+  await platformIdContract.connect(bob).updateProfileData(bobTalentLayerIdPlatform, cid)
   await platformIdContract.connect(bob).updateOriginServiceFeeRate(bobTalentLayerIdPlatform, 1500)
   await platformIdContract
     .connect(bob)

--- a/scripts/playground/3-make-proposal.ts
+++ b/scripts/playground/3-make-proposal.ts
@@ -6,8 +6,6 @@ const bobTlId = 2
 const carolTlId = 3
 const daveTlId = 4
 
-const now = Math.floor(Date.now() / 1000)
-const proposalExpirationDate = now + 60 * 60 * 24 * 15
 const minTokenWhitelistTransactionAmount = ethers.utils.parseUnits('0.0001', 18)
 
 /*
@@ -16,6 +14,7 @@ Bob and Carol for the first service (with ETH and Token) and Dave for the second
 */
 
 import hre = require('hardhat')
+import { proposalExpirationDate } from './constants'
 
 // Then Alice create a service, and others add proposals
 async function main() {

--- a/scripts/playground/6-accept-ETHproposal.ts
+++ b/scripts/playground/6-accept-ETHproposal.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../.deployment/deploymentManager'
 import hre = require('hardhat')
+import { metaEvidenceCid } from './constants'
 
 /*
 In this script Alice will accept Carol's proposal with an ETH transaction
@@ -73,7 +74,7 @@ async function main() {
   await talentLayerEscrow.connect(alice).createTransaction(
     firstServiceId,
     3, //proposalId/talentLayerId of carol.
-    '_metaEvidence',
+    metaEvidenceCid,
     proposal.dataUri,
     { value: totalAmount },
   )

--- a/scripts/playground/6-accept-tokenProposal.ts
+++ b/scripts/playground/6-accept-tokenProposal.ts
@@ -2,6 +2,7 @@ import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../.deployment/deploymentManager'
 import { waitConfirmations } from '../utils/waitConfirmations'
 import hre = require('hardhat')
+import { metaEvidenceCid } from './constants'
 
 /*
 In this script Alice will accept Dave's proposal with Token transaction
@@ -86,7 +87,7 @@ async function main() {
   await talentLayerEscrow.connect(alice).createTransaction(
     secondServiceId,
     4, //proposalId/talentLayerId of Dave.
-    '_metaEvidence',
+    metaEvidenceCid,
     proposal.dataUri,
   )
 }

--- a/scripts/playground/constants.ts
+++ b/scripts/playground/constants.ts
@@ -7,3 +7,7 @@ export const arbitrationCost = BigNumber.from(10)
 export const disputeId = 0
 export const arbitrationFeeTimeout = 3600 * 24 * 30
 export const rulingId = 1
+export const cid = 'QmQLVYemsvvqk58y8UTrCEp8MrcQaMzzT2e2duDEmFG99Z'
+export const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
+export const now = Math.floor(Date.now() / 1000)
+export const proposalExpirationDate = now + 60 * 60 * 24 * 15

--- a/scripts/playground/disputeResolution/0-setup.ts
+++ b/scripts/playground/disputeResolution/0-setup.ts
@@ -1,7 +1,13 @@
 import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
 import postToIPFS from '../../utils/ipfs'
-import { arbitrationCost, arbitrationFeeTimeout, transactionAmount } from './constants'
+import {
+  arbitrationCost,
+  arbitrationFeeTimeout,
+  cid,
+  proposalExpirationDate,
+  transactionAmount,
+} from '../constants'
 
 import hre = require('hardhat')
 
@@ -84,13 +90,21 @@ async function main() {
   console.log('Minted TL Id for Bob')
 
   // Alice, the buyer, initiates a new open service
-  await talentLayerService.connect(alice).createService(aliceTlId, carolPlatformId, 'cid')
+  await talentLayerService.connect(alice).createService(aliceTlId, carolPlatformId, cid)
   console.log('Open service created by Alice')
 
   // Bob, the seller, creates a proposal for the service
   await talentLayerService
     .connect(bob)
-    .createProposal(bobTlId, serviceId, ethAddress, transactionAmount, 'cid')
+    .createProposal(
+      bobTlId,
+      serviceId,
+      ethAddress,
+      transactionAmount,
+      carolPlatformId,
+      cid,
+      proposalExpirationDate,
+    )
   console.log('Proposal for service created by Bob')
 
   // Upload meta evidence to IPFS
@@ -132,9 +146,11 @@ async function main() {
       .mul(protocolEscrowFeeRate + originValidatedProposalFeeRate + originServiceFeeRate)
       .div(feeDivider),
   )
-  await talentLayerEscrow.connect(alice).createTransaction(serviceId, proposalId, metaEvidence, {
-    value: totalTransactionAmount,
-  })
+  await talentLayerEscrow
+    .connect(alice)
+    .createTransaction(serviceId, proposalId, metaEvidence, cid, {
+      value: totalTransactionAmount,
+    })
 }
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/scripts/playground/disputeResolution/1-pay-arbitration-fee.ts
+++ b/scripts/playground/disputeResolution/1-pay-arbitration-fee.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
-import { arbitrationCost, transactionId } from './constants'
+import { arbitrationCost, transactionId } from '../constants'
 
 import hre = require('hardhat')
 

--- a/scripts/playground/disputeResolution/2-create-dispute.ts
+++ b/scripts/playground/disputeResolution/2-create-dispute.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
-import { arbitrationCost, transactionId } from './constants'
+import { arbitrationCost, transactionId } from '../constants'
 
 import hre = require('hardhat')
 

--- a/scripts/playground/disputeResolution/3-submit-evidence.ts
+++ b/scripts/playground/disputeResolution/3-submit-evidence.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
 import postToIPFS from '../../utils/ipfs'
-import { transactionId } from './constants'
+import { transactionId } from '../constants'
 
 import hre = require('hardhat')
 

--- a/scripts/playground/disputeResolution/4-submit-ruling.ts
+++ b/scripts/playground/disputeResolution/4-submit-ruling.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'hardhat'
 import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
-import { disputeId, rulingId } from './constants'
+import { disputeId, rulingId } from '../constants'
 
 import hre = require('hardhat')
 

--- a/test/batch/delegationSystem.ts
+++ b/test/batch/delegationSystem.ts
@@ -19,6 +19,8 @@ const trasactionId = 0
 const transactionAmount = 100000
 const ethAddress = '0x0000000000000000000000000000000000000000'
 const minTokenWhitelistTransactionAmount = 10
+const cid = 'QmQLVYemsvvqk58y8UTrCEp8MrcQaMzzT2e2duDEmFG99Z'
+const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
 
 const now = Math.floor(Date.now() / 1000)
 const proposalExpirationDate = now + 60 * 60 * 24 * 15
@@ -103,10 +105,10 @@ describe('Delegation System', function () {
 
     it('Dave can update Alice profile data', async function () {
       // Fails if caller is not the owner or delegate
-      const failTx = talentLayerID.connect(eve).updateProfileData(aliceTlId, 'newUri')
+      const failTx = talentLayerID.connect(eve).updateProfileData(aliceTlId, cid)
       await expect(failTx).to.be.revertedWith('Not owner or delegate')
 
-      const tx = await talentLayerID.connect(dave).updateProfileData(aliceTlId, 'newUri')
+      const tx = await talentLayerID.connect(dave).updateProfileData(aliceTlId, cid)
       await expect(tx).to.not.be.reverted
     })
   })
@@ -119,19 +121,17 @@ describe('Delegation System', function () {
 
     it('Dave can open a service on behalf of Alice', async function () {
       // Fails if caller is not the owner or delegate
-      const tx = talentLayerService.connect(eve).createService(aliceTlId, carolPlatformId, 'cid')
+      const tx = talentLayerService.connect(eve).createService(aliceTlId, carolPlatformId, cid)
       await expect(tx).to.be.revertedWith('Not owner or delegate')
 
-      await talentLayerService.connect(dave).createService(aliceTlId, carolPlatformId, 'cid')
+      await talentLayerService.connect(dave).createService(aliceTlId, carolPlatformId, cid)
       const serviceData = await talentLayerService.services(1)
 
       expect(serviceData.ownerId.toNumber()).to.be.equal(aliceTlId)
     })
 
     it('Dave can update service data on behalf of Alice', async function () {
-      const tx = await talentLayerService
-        .connect(dave)
-        .updateServiceData(aliceTlId, serviceId, 'newCid')
+      const tx = await talentLayerService.connect(dave).updateServiceData(aliceTlId, serviceId, cid)
       await expect(tx).to.not.be.reverted
     })
 
@@ -144,7 +144,7 @@ describe('Delegation System', function () {
           ethAddress,
           transactionAmount,
           carolPlatformId,
-          'uri',
+          cid,
           proposalExpirationDate,
         )
       const proposal = await talentLayerService.proposals(serviceId, bobTlId)
@@ -159,7 +159,7 @@ describe('Delegation System', function () {
           serviceId,
           ethAddress,
           transactionAmount,
-          'newUri',
+          cid,
           proposalExpirationDate,
         )
       await expect(tx).to.not.be.reverted
@@ -183,7 +183,7 @@ describe('Delegation System', function () {
       // Accept proposal through deposit
       await talentLayerEscrow
         .connect(alice)
-        .createTransaction(serviceId, bobTlId, '', proposal.dataUri, {
+        .createTransaction(serviceId, bobTlId, metaEvidenceCid, proposal.dataUri, {
           value: totalAmount,
         })
 
@@ -202,10 +202,10 @@ describe('Delegation System', function () {
 
     it('Dave can create a review on behalf of Alice', async function () {
       // Fails is caller is not the owner or delegate
-      const failTx = talentLayerReview.connect(eve).mint(aliceTlId, serviceId, 'uri', 5)
+      const failTx = talentLayerReview.connect(eve).mint(aliceTlId, serviceId, cid, 5)
       await expect(failTx).to.be.revertedWith('Not owner or delegate')
 
-      const tx = await talentLayerReview.connect(dave).mint(aliceTlId, serviceId, 'uri', 5)
+      const tx = await talentLayerReview.connect(dave).mint(aliceTlId, serviceId, cid, 5)
       await expect(tx).to.not.be.reverted
     })
   })
@@ -218,7 +218,7 @@ describe('Delegation System', function () {
     })
 
     it("Dave can't do actions on behalf of Alice anymore", async function () {
-      const tx = talentLayerService.connect(dave).createService(aliceTlId, carolPlatformId, 'cid')
+      const tx = talentLayerService.connect(dave).createService(aliceTlId, carolPlatformId, cid)
       await expect(tx).to.be.revertedWith('Not owner or delegate')
     })
   })

--- a/test/batch/delegationSystem.ts
+++ b/test/batch/delegationSystem.ts
@@ -8,7 +8,13 @@ import {
   TalentLayerPlatformID,
   TalentLayerReview,
 } from '../../typechain-types'
-import { MintStatus } from '../utils/constant'
+import {
+  cid,
+  metaEvidenceCid,
+  minTokenWhitelistTransactionAmount,
+  MintStatus,
+  proposalExpirationDate,
+} from '../utils/constant'
 import { deploy } from '../utils/deploy'
 
 const carolPlatformId = 1
@@ -18,12 +24,6 @@ const serviceId = 1
 const trasactionId = 0
 const transactionAmount = 100000
 const ethAddress = '0x0000000000000000000000000000000000000000'
-const minTokenWhitelistTransactionAmount = 10
-const cid = 'QmQLVYemsvvqk58y8UTrCEp8MrcQaMzzT2e2duDEmFG99Z'
-const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
-
-const now = Math.floor(Date.now() / 1000)
-const proposalExpirationDate = now + 60 * 60 * 24 * 15
 
 /**
  * Deploys contracts and sets up the context for TalentLayerId contract.

--- a/test/batch/disputeResolution.ts
+++ b/test/batch/disputeResolution.ts
@@ -24,13 +24,14 @@ const transactionAmount = BigNumber.from(1000000)
 const ethAddress = '0x0000000000000000000000000000000000000000'
 const arbitrationCost = BigNumber.from(10)
 const disputeId = 0
-const metaEvidence = 'metaEvidence'
 const feeDivider = 10000
 const arbitrationFeeTimeout = 3600 * 24
 const minTokenWhitelistTransactionAmount = 10
 
 const now = Math.floor(Date.now() / 1000)
 const proposalExpirationDate = now + 60 * 60 * 24 * 15
+const cid = 'QmQLVYemsvvqk58y8UTrCEp8MrcQaMzzT2e2duDEmFG99Z'
+const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
 
 /**
  * Deploys contract and sets up the context for dispute resolution.
@@ -88,7 +89,7 @@ async function deployAndSetup(
   await talentLayerID.connect(dave).mint(carolPlatformId, 'dave')
 
   // Alice, the buyer, initiates a new open service
-  await talentLayerService.connect(alice).createService(aliceTlId, carolPlatformId, 'cid')
+  await talentLayerService.connect(alice).createService(aliceTlId, carolPlatformId, cid)
 
   // Bob, the seller, creates a proposal for the service
   await talentLayerService
@@ -99,7 +100,7 @@ async function deployAndSetup(
       tokenAddress,
       transactionAmount,
       carolPlatformId,
-      'cid',
+      cid,
       proposalExpirationDate,
     )
 
@@ -153,7 +154,7 @@ describe('Dispute Resolution, standard flow', function () {
 
       tx = await talentLayerEscrow
         .connect(alice)
-        .createTransaction(serviceId, proposalId, metaEvidence, proposal.dataUri, {
+        .createTransaction(serviceId, proposalId, metaEvidenceCid, proposal.dataUri, {
           value: totalTransactionAmount,
         })
     })
@@ -168,7 +169,7 @@ describe('Dispute Resolution, standard flow', function () {
     it('MetaEvidence is submitted', async function () {
       await expect(tx)
         .to.emit(talentLayerEscrow, 'MetaEvidence')
-        .withArgs(transactionId, metaEvidence)
+        .withArgs(transactionId, metaEvidenceCid)
     })
 
     it('Transaction is created', async function () {
@@ -490,7 +491,7 @@ describe('Dispute Resolution, with party failing to pay arbitration fee on time'
 
     await talentLayerEscrow
       .connect(alice)
-      .createTransaction(serviceId, proposalId, metaEvidence, proposal.dataUri, {
+      .createTransaction(serviceId, proposalId, metaEvidenceCid, proposal.dataUri, {
         value: totalTransactionAmount,
       })
 
@@ -562,7 +563,7 @@ describe('Dispute Resolution, arbitrator abstaining from giving a ruling', funct
 
     await talentLayerEscrow
       .connect(alice)
-      .createTransaction(serviceId, proposalId, metaEvidence, proposal.dataUri, {
+      .createTransaction(serviceId, proposalId, metaEvidenceCid, proposal.dataUri, {
         value: totalTransactionAmount,
       })
 
@@ -694,7 +695,7 @@ describe('Dispute Resolution, with ERC20 token transaction', function () {
     // Create transaction
     await talentLayerEscrow
       .connect(alice)
-      .createTransaction(serviceId, proposalId, metaEvidence, proposal.dataUri)
+      .createTransaction(serviceId, proposalId, metaEvidenceCid, proposal.dataUri)
 
     // Alice wants to raise a dispute and pays the arbitration fee
     await talentLayerEscrow.connect(alice).payArbitrationFeeBySender(transactionId, {

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -13,7 +13,14 @@ import {
   TalentLayerPlatformID,
   TalentLayerReview,
 } from '../../typechain-types'
-import { MintStatus } from '../utils/constant'
+import {
+  cid,
+  cid2,
+  metaEvidenceCid,
+  minTokenWhitelistTransactionAmount,
+  MintStatus,
+  proposalExpirationDate,
+} from '../utils/constant'
 
 const aliceTlId = 1
 const bobTlId = 2
@@ -21,14 +28,6 @@ const carolTlId = 3
 
 const alicePlatformId = 1
 const bobPlatformId = 2
-
-const now = Math.floor(Date.now() / 1000)
-const proposalExpirationDate = now + 60 * 60 * 24 * 15
-const minTokenWhitelistTransactionAmount = 10
-
-const cid = 'QmQLVYemsvvqk58y8UTrCEp8MrcQaMzzT2e2duDEmFG99Z'
-const cid2 = 'QmcbtH86xKGM4rNhpzcYMEjGF9qKMQ5Rdep8zfe3ndLtV1'
-const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
 
 describe('TalentLayer protocol global testing', function () {
   // we define the types of the variables we will use

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -26,6 +26,10 @@ const now = Math.floor(Date.now() / 1000)
 const proposalExpirationDate = now + 60 * 60 * 24 * 15
 const minTokenWhitelistTransactionAmount = 10
 
+const cid = 'QmQLVYemsvvqk58y8UTrCEp8MrcQaMzzT2e2duDEmFG99Z'
+const cid2 = 'QmcbtH86xKGM4rNhpzcYMEjGF9qKMQ5Rdep8zfe3ndLtV1'
+const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
+
 describe('TalentLayer protocol global testing', function () {
   // we define the types of the variables we will use
   let deployer: SignerWithAddress,
@@ -123,11 +127,11 @@ describe('TalentLayer protocol global testing', function () {
     })
 
     it('Alice can update the platform Data', async function () {
-      await talentLayerPlatformID.connect(alice).updateProfileData(aliceTlId, 'newPlatId')
+      await talentLayerPlatformID.connect(alice).updateProfileData(aliceTlId, cid2)
 
       const aliceUserId = await talentLayerPlatformID.ids(alice.address)
       const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
-      expect(alicePlatformData.dataUri).to.be.equal('newPlatId')
+      expect(alicePlatformData.dataUri).to.be.equal(cid2)
     })
 
     it('Alice should not be able to transfer her PlatformId Id to Bob', async function () {
@@ -680,10 +684,10 @@ describe('TalentLayer protocol global testing', function () {
 
     it("Alice can't create a new service with a talentLayerId 0", async function () {
       await expect(
-        talentLayerService.connect(alice).createService(aliceTlId, 0, 'cid0'),
+        talentLayerService.connect(alice).createService(aliceTlId, 0, cid),
       ).to.be.revertedWith('Invalid platform ID')
       await expect(
-        talentLayerService.connect(alice).createService(aliceTlId, 0, 'cid0'),
+        talentLayerService.connect(alice).createService(aliceTlId, 0, cid),
       ).to.be.revertedWith('Invalid platform ID')
     })
 
@@ -692,36 +696,36 @@ describe('TalentLayer protocol global testing', function () {
       const alicePlatformServicePostingFee = platform.servicePostingFee
 
       // Alice will create 4 Open services fo the whole unit test process
-      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, 'CID1', {
+      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, cid, {
         value: alicePlatformServicePostingFee,
       })
       const serviceData = await talentLayerService.services(1)
 
       // service 2
-      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, 'CID2', {
+      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, cid, {
         value: alicePlatformServicePostingFee,
       })
       await talentLayerService.services(2)
 
       // service 3
-      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, 'CID3', {
+      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, cid, {
         value: alicePlatformServicePostingFee,
       })
       await talentLayerService.services(3)
 
       // service 4
-      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, 'CID4', {
+      await talentLayerService.connect(alice).createService(aliceTlId, alicePlatformId, cid, {
         value: alicePlatformServicePostingFee,
       })
       await talentLayerService.services(4)
 
       // service 5 (will be cancelled)
-      await talentLayerService.connect(alice).createService(aliceTlId, 1, 'CID5')
+      await talentLayerService.connect(alice).createService(aliceTlId, 1, cid)
       await talentLayerService.services(5)
 
       expect(serviceData.status.toString()).to.be.equal('0')
       expect(serviceData.ownerId).to.be.equal(aliceTlId)
-      expect(serviceData.dataUri).to.be.equal('CID1')
+      expect(serviceData.dataUri).to.be.equal(cid)
       expect(serviceData.platformId).to.be.equal(1)
     })
 
@@ -732,11 +736,9 @@ describe('TalentLayer protocol global testing', function () {
     })
 
     it('Alice can update her service data', async function () {
-      await talentLayerService
-        .connect(alice)
-        .updateServiceData(aliceTlId, 1, 'aliceUpdateHerFirstService')
+      await talentLayerService.connect(alice).updateServiceData(aliceTlId, 1, cid2)
       const serviceData = await talentLayerService.services(1)
-      expect(serviceData.dataUri).to.be.equal('aliceUpdateHerFirstService')
+      expect(serviceData.dataUri).to.be.equal(cid2)
     })
 
     it('Alice can cancel her own service', async function () {
@@ -757,15 +759,7 @@ describe('TalentLayer protocol global testing', function () {
       expect(
         talentLayerService
           .connect(bob)
-          .createProposal(
-            bobTlId,
-            5,
-            rateToken,
-            1,
-            bobPlatformId,
-            'proposalOnCancelledService',
-            proposalExpirationDate,
-          ),
+          .createProposal(bobTlId, 5, rateToken, 1, bobPlatformId, cid, proposalExpirationDate),
       ).to.be.revertedWith('Service is not opened')
     })
 
@@ -785,18 +779,9 @@ describe('TalentLayer protocol global testing', function () {
       await expect(
         talentLayerService
           .connect(bob)
-          .createProposal(
-            bobTlId,
-            1,
-            rateToken,
-            9,
-            alicePlatformId,
-            'proposal1FromBobToAlice1Service',
-            proposalExpirationDate,
-            {
-              value: alicePlatformProposalPostingFee,
-            },
-          ),
+          .createProposal(bobTlId, 1, rateToken, 9, alicePlatformId, cid, proposalExpirationDate, {
+            value: alicePlatformProposalPostingFee,
+          }),
       ).to.be.revertedWith('Amount is too low')
     })
 
@@ -814,18 +799,9 @@ describe('TalentLayer protocol global testing', function () {
       // Bob creates a proposal on Platform 1
       await talentLayerService
         .connect(bob)
-        .createProposal(
-          bobTlId,
-          1,
-          rateToken,
-          15,
-          alicePlatformId,
-          'proposal1FromBobToAlice1Service',
-          proposalExpirationDate,
-          {
-            value: alicePlatformProposalPostingFee,
-          },
-        )
+        .createProposal(bobTlId, 1, rateToken, 15, alicePlatformId, cid2, proposalExpirationDate, {
+          value: alicePlatformProposalPostingFee,
+        })
 
       const serviceData = await talentLayerService.services(1)
       const proposalDataAfter = await talentLayerService.getProposal(1, bobTid)
@@ -838,7 +814,7 @@ describe('TalentLayer protocol global testing', function () {
 
       expect(proposalDataAfter.rateToken).to.be.equal(rateToken)
       expect(proposalDataAfter.rateAmount.toString()).to.be.equal('15')
-      expect(proposalDataAfter.dataUri).to.be.equal('proposal1FromBobToAlice1Service')
+      expect(proposalDataAfter.dataUri).to.be.equal(cid2)
       expect(proposalDataAfter.ownerId).to.be.equal(bobTlId)
       expect(proposalDataAfter.status.toString()).to.be.equal('0')
     })
@@ -851,18 +827,9 @@ describe('TalentLayer protocol global testing', function () {
       // Carol creates a proposal on Platform 2
       await talentLayerService
         .connect(carol)
-        .createProposal(
-          carolTlId,
-          1,
-          rateToken,
-          16,
-          bobPlatformId,
-          'proposal1FromCarolToAlice1Service',
-          proposalExpirationDate,
-          {
-            value: bobPlatformProposalPostingFee,
-          },
-        )
+        .createProposal(carolTlId, 1, rateToken, 16, bobPlatformId, cid2, proposalExpirationDate, {
+          value: bobPlatformProposalPostingFee,
+        })
       await talentLayerService.services(1)
       // get proposal info
       const carolTid = await talentLayerID.ids(carol.address)
@@ -882,7 +849,7 @@ describe('TalentLayer protocol global testing', function () {
             nonListedRateToken,
             16,
             alicePlatformId,
-            'proposal1FromCarolToAlice1Service',
+            cid2,
             proposalExpirationDate,
             { value: alicePlatformProposalPostingFee },
           ),
@@ -898,32 +865,18 @@ describe('TalentLayer protocol global testing', function () {
 
       await talentLayerService
         .connect(bob)
-        .updateProposal(
-          bobTlId,
-          1,
-          rateToken,
-          18,
-          'updateProposal1FromBobToAlice1Service',
-          proposalExpirationDate,
-        )
+        .updateProposal(bobTlId, 1, rateToken, 18, cid, proposalExpirationDate)
 
       const proposalDataAfter = await talentLayerService.getProposal(1, bobTid)
       expect(proposalDataAfter.rateAmount.toString()).to.be.equal('18')
-      expect(proposalDataAfter.dataUri).to.be.equal('updateProposal1FromBobToAlice1Service')
+      expect(proposalDataAfter.dataUri).to.be.equal(cid)
     })
 
     it('Should revert if Bob updates his proposal with a non-whitelisted payment token ', async function () {
       await expect(
         talentLayerService
           .connect(bob)
-          .updateProposal(
-            bobTlId,
-            1,
-            nonListedRateToken,
-            2,
-            'updateProposal1FromBobToAlice1Service',
-            proposalExpirationDate,
-          ),
+          .updateProposal(bobTlId, 1, nonListedRateToken, 2, cid2, proposalExpirationDate),
       ).to.be.revertedWith('This token is not allowed')
     })
   })
@@ -944,7 +897,7 @@ describe('TalentLayer protocol global testing', function () {
         await expect(
           talentLayerEscrow
             .connect(alice)
-            .createTransaction(serviceId, proposalIdBob, '_metaEvidence', proposalDataUri),
+            .createTransaction(serviceId, proposalIdBob, metaEvidenceCid, proposalDataUri),
         ).to.be.revertedWith('ERC721: invalid token ID')
       })
 
@@ -961,7 +914,7 @@ describe('TalentLayer protocol global testing', function () {
             token.address,
             amountBob,
             bobPlatformId,
-            'proposal2FromBobToAlice2Service',
+            cid,
             proposalExpirationDate,
             { value: bobPlatformProposalPostingFee },
           )
@@ -980,7 +933,7 @@ describe('TalentLayer protocol global testing', function () {
             token.address,
             amountCarol,
             bobPlatformId,
-            'proposal2FromCarolToAlice2Service',
+            cid,
             proposalExpirationDate,
             { value: bobPlatformProposalPostingFee },
           )
@@ -1036,7 +989,7 @@ describe('TalentLayer protocol global testing', function () {
 
         const transaction = await talentLayerEscrow
           .connect(alice)
-          .createTransaction(serviceId, proposalIdBob, '_metaEvidence', proposal.dataUri)
+          .createTransaction(serviceId, proposalIdBob, metaEvidenceCid, proposal.dataUri)
         await expect(transaction).to.changeTokenBalances(
           token,
           [talentLayerEscrow.address, alice, bob],
@@ -1063,7 +1016,7 @@ describe('TalentLayer protocol global testing', function () {
         await expect(
           talentLayerEscrow
             .connect(alice)
-            .createTransaction(serviceId, proposalIdCarol, '_metaEvidence', proposalDataUri),
+            .createTransaction(serviceId, proposalIdCarol, metaEvidenceCid, proposalDataUri),
         ).to.be.reverted
       })
 
@@ -1154,7 +1107,7 @@ describe('TalentLayer protocol global testing', function () {
         // Create the service
         const serviceId = 6
         const proposalIdBob = (await talentLayerID.ids(bob.address)).toNumber()
-        await talentLayerService.connect(alice).createService(aliceTlId, 1, 'CID6')
+        await talentLayerService.connect(alice).createService(aliceTlId, 1, cid)
         await talentLayerService.services(serviceId)
         // Create the proposal
         const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
@@ -1168,7 +1121,7 @@ describe('TalentLayer protocol global testing', function () {
             rateToken,
             15,
             alicePlatformId,
-            'proposalOnService',
+            cid,
             proposalExpirationDate,
             {
               value: alicePlatformProposalPostingFee,
@@ -1197,7 +1150,7 @@ describe('TalentLayer protocol global testing', function () {
         await expect(
           talentLayerEscrow
             .connect(alice)
-            .createTransaction(serviceId, proposalIdBob, '_metaEvidence', proposal.dataUri),
+            .createTransaction(serviceId, proposalIdBob, metaEvidenceCid, proposal.dataUri),
         ).to.be.revertedWith('Service status not open')
       })
 
@@ -1297,7 +1250,7 @@ describe('TalentLayer protocol global testing', function () {
         await expect(
           talentLayerEscrow
             .connect(alice)
-            .createTransaction(serviceId, proposalIdBob, '_metaEvidence', proposal.dataUri),
+            .createTransaction(serviceId, proposalIdBob, metaEvidenceCid, proposal.dataUri),
         ).to.be.reverted
       })
 
@@ -1314,7 +1267,7 @@ describe('TalentLayer protocol global testing', function () {
             ethAddress,
             amountBob,
             bobPlatformId,
-            'proposal3FromBobToAlice3Service',
+            cid,
             proposalExpirationDate,
             { value: bobPlatformProposalPostingFee },
           )
@@ -1333,7 +1286,7 @@ describe('TalentLayer protocol global testing', function () {
             ethAddress,
             amountCarol,
             bobPlatformId,
-            'proposal3FromCarolToAlice3Service',
+            cid,
             proposalExpirationDate,
             { value: bobPlatformProposalPostingFee },
           )
@@ -1343,27 +1296,14 @@ describe('TalentLayer protocol global testing', function () {
       it('Bob will try to front run the proposal validation by changing the proposal dataUri.', async function () {
         await talentLayerService
           .connect(bob)
-          .updateProposal(
-            bobTlId,
-            serviceId,
-            ethAddress,
-            amountBob,
-            'frontRunProposal3FromBobToAlice3Service',
-            proposalExpirationDate,
-          )
+          .updateProposal(bobTlId, serviceId, ethAddress, amountBob, cid2, proposalExpirationDate)
 
         await expect(
           talentLayerEscrow
             .connect(alice)
-            .createTransaction(
-              serviceId,
-              proposalIdBob,
-              '_metaEvidence',
-              'proposal3FromBobToAlice3Service',
-              {
-                value: totalAmount,
-              },
-            ),
+            .createTransaction(serviceId, proposalIdBob, metaEvidenceCid, cid, {
+              value: totalAmount,
+            }),
         ).to.be.revertedWith('Proposal dataUri has changed')
       })
 
@@ -1371,7 +1311,7 @@ describe('TalentLayer protocol global testing', function () {
         const proposal = await talentLayerService.proposals(serviceId, bobTlId)
         const transaction = await talentLayerEscrow
           .connect(alice)
-          .createTransaction(serviceId, proposalIdBob, '_metaEvidence', proposal.dataUri, {
+          .createTransaction(serviceId, proposalIdBob, metaEvidenceCid, proposal.dataUri, {
             value: totalAmount,
           })
         await expect(transaction).to.changeEtherBalances(
@@ -1399,7 +1339,7 @@ describe('TalentLayer protocol global testing', function () {
         await expect(
           talentLayerEscrow
             .connect(alice)
-            .createTransaction(serviceId, proposalIdCarol, '_metaEvidence', 'dataUri', {
+            .createTransaction(serviceId, proposalIdCarol, metaEvidenceCid, 'dataUri', {
               value: amountCarol,
             }),
         ).to.be.reverted
@@ -1551,24 +1491,24 @@ describe('TalentLayer protocol global testing', function () {
 
     it("Alice can't write a review as the service is not finished", async function () {
       await expect(
-        talentLayerReview.connect(alice).mint(aliceTlId, unfinishedServiceId, 'cidReview', 3),
+        talentLayerReview.connect(alice).mint(aliceTlId, unfinishedServiceId, cid, 3),
       ).to.be.revertedWith('The service is not finished yet')
     })
 
     it("Carol can't write a review as she's not an actor of the service", async function () {
       await expect(
-        talentLayerReview.connect(carol).mint(carolTlId, finishedServiceId, 'cidReview', 5),
+        talentLayerReview.connect(carol).mint(carolTlId, finishedServiceId, cid, 5),
       ).to.be.revertedWith("You're not an actor of this service")
     })
 
     it('The rating needs to be between 0 and 5', async function () {
       await expect(
-        talentLayerReview.connect(alice).mint(aliceTlId, finishedServiceId, 'cidReview', 6),
+        talentLayerReview.connect(alice).mint(aliceTlId, finishedServiceId, cid, 6),
       ).to.be.revertedWith('Invalid rating')
     })
 
     it('Alice can review Bob for the service they had', async function () {
-      await talentLayerReview.connect(alice).mint(aliceTlId, finishedServiceId, 'cidReview', 4)
+      await talentLayerReview.connect(alice).mint(aliceTlId, finishedServiceId, cid, 4)
 
       const owner = await talentLayerReview.ownerOf(bobReviewId)
       expect(owner).to.be.equal(bob.address)
@@ -1579,7 +1519,7 @@ describe('TalentLayer protocol global testing', function () {
       const review = await talentLayerReview.getReview(bobReviewId)
       expect(review.id).to.be.equal(bobReviewId)
       expect(review.ownerId).to.be.equal(bobTlId)
-      expect(review.dataUri).to.be.equal('cidReview')
+      expect(review.dataUri).to.be.equal(cid)
       expect(review.serviceId).to.be.equal(finishedServiceId)
       expect(review.rating).to.be.equal(4)
 
@@ -1588,7 +1528,7 @@ describe('TalentLayer protocol global testing', function () {
     })
 
     it('Bob can review Alice for the service they had', async function () {
-      await talentLayerReview.connect(bob).mint(bobTlId, finishedServiceId, 'cidReview', 5)
+      await talentLayerReview.connect(bob).mint(bobTlId, finishedServiceId, cid, 5)
 
       const owner = await talentLayerReview.ownerOf(aliceReviewId)
       expect(owner).to.be.equal(alice.address)
@@ -1599,13 +1539,13 @@ describe('TalentLayer protocol global testing', function () {
 
     it("Alice can't review Bob again for the same service", async function () {
       await expect(
-        talentLayerReview.connect(alice).mint(aliceTlId, finishedServiceId, 'cidReview', 4),
+        talentLayerReview.connect(alice).mint(aliceTlId, finishedServiceId, cid, 4),
       ).to.be.revertedWith('You have already minted a review for this service')
     })
 
     it("Bob can't review Alice again for the same service", async function () {
       await expect(
-        talentLayerReview.connect(bob).mint(bobTlId, finishedServiceId, 'cidReview', 4),
+        talentLayerReview.connect(bob).mint(bobTlId, finishedServiceId, cid, 4),
       ).to.be.revertedWith('You have already minted a review for this service')
     })
 

--- a/test/utils/constant.ts
+++ b/test/utils/constant.ts
@@ -1,3 +1,12 @@
+export const minTokenWhitelistTransactionAmount = 10
+export const cid = 'QmQLVYemsvvqk58y8UTrCEp8MrcQaMzzT2e2duDEmFG99Z'
+export const cid2 = 'QmcbtH86xKGM4rNhpzcYMEjGF9qKMQ5Rdep8zfe3ndLtV1'
+export const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
+export const now = Math.floor(Date.now() / 1000)
+export const proposalExpirationDate = now + 60 * 60 * 24 * 15
+export const feeDivider = 10000
+export const arbitrationFeeTimeout = 3600 * 24
+
 export enum TransactionStatus {
   NoDispute,
   WaitingSender,


### PR DESCRIPTION
IPFS uri validation: The only way to validate an ipfs cid is to download the file, there is not checksum possible. It still better to validate that the string is a 46 characters length. Note that there is a way to cut the URI in 3 pieces as it uses the multihash standard but this seems to add to more complexity: https://github.com/multiformats/multihash. 