### PR TITLE
Use hash for taken handles

### DIFF
--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -52,8 +52,8 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     /// TalentLayer Platform ID registry
     ITalentLayerPlatformID public talentLayerPlatformIdContract;
 
-    /// Taken handles
-    mapping(string => bool) public takenHandles;
+    /// Taken handles (using hash of the handle as key)
+    mapping(bytes32 => bool) public takenHandles;
 
     /// TalentLayer ID to Profile struct
     mapping(uint256 => Profile) public profiles;
@@ -321,8 +321,10 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
         Profile storage profile = profiles[userProfileId];
         profile.platformId = _platformId;
         profile.handle = _handle;
-        takenHandles[_handle] = true;
         ids[_userAddress] = userProfileId;
+
+        bytes32 handleHash = keccak256(bytes(_handle));
+        takenHandles[handleHash] = true;
 
         emit Mint(_userAddress, userProfileId, _handle, _platformId, _fee);
         return userProfileId;
@@ -468,7 +470,8 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
         uint256 _platformId
     ) {
         require(numberMinted(_userAddress) == 0, "You already have a TalentLayerID");
-        require(!takenHandles[_handle], "Handle already taken");
+        bytes32 handleHash = keccak256(bytes(_handle));
+        require(!takenHandles[handleHash], "Handle already taken");
         talentLayerPlatformIdContract.isValid(_platformId);
         _validateHandle(_handle);
         _;

--- a/contracts/TalentLayerPlatformID.sol
+++ b/contracts/TalentLayerPlatformID.sol
@@ -55,9 +55,9 @@ contract TalentLayerPlatformID is ERC721Upgradeable, AccessControlUpgradeable, U
     }
 
     /**
-     * @notice Taken Platform name
+     * @notice Taken Platform name (using hash of the name as key)
      */
-    mapping(string => bool) public takenNames;
+    mapping(bytes32 => bool) public takenNames;
 
     /**
      * @notice Platform ID to Platform struct
@@ -422,8 +422,10 @@ contract TalentLayerPlatformID is ERC721Upgradeable, AccessControlUpgradeable, U
         platform.name = _platformName;
         platform.id = platformId;
         platform.arbitrationFeeTimeout = minArbitrationFeeTimeout;
-        takenNames[_platformName] = true;
         ids[_platformAddress] = platformId;
+
+        bytes32 nameHash = keccak256(bytes(_platformName));
+        takenNames[nameHash] = true;
 
         emit Mint(_platformAddress, platformId, _platformName, mintFee, minArbitrationFeeTimeout);
 
@@ -555,7 +557,8 @@ contract TalentLayerPlatformID is ERC721Upgradeable, AccessControlUpgradeable, U
         }
         require(msg.value == mintFee, "Incorrect amount of ETH for mint fee");
         require(numberMinted(_platformAddress) == 0, "Platform already has a Platform ID");
-        require(!takenNames[_platformName], "Name already taken");
+        bytes32 nameHash = keccak256(bytes(_platformName));
+        require(!takenNames[nameHash], "Name already taken");
 
         _validateHandle(_platformName);
         _;

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -53,7 +53,7 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     ITalentLayerPlatformID public talentLayerPlatformIdContract;
 
     /// Taken handles
-    mapping(string => bool) public takenHandles;
+    mapping(bytes32 => bool) public takenHandles;
 
     /// TalentLayer ID to Profile struct
     mapping(uint256 => Profile) public profiles;
@@ -309,7 +309,10 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
         Profile storage profile = profiles[userProfileId];
         profile.platformId = _platformId;
         profile.handle = _handle;
-        takenHandles[_handle] = true;
+
+        bytes32 handleHash = keccak256(bytes(_handle));
+        takenHandles[handleHash] = true;
+
         ids[_userAddress] = userProfileId;
 
         emit Mint(_userAddress, userProfileId, _handle, _platformId, _fee);
@@ -469,7 +472,8 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
         uint256 _platformId
     ) {
         require(numberMinted(_userAddress) == 0, "You already have a TalentLayerID");
-        require(!takenHandles[_handle], "Handle already taken");
+        bytes32 handleHash = keccak256(bytes(_handle));
+        require(!takenHandles[handleHash], "Handle already taken");
         talentLayerPlatformIdContract.isValid(_platformId);
         _validateHandle(_handle);
         _;

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -2,6 +2,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { expect } from 'chai'
 import { BigNumber } from 'ethers'
 import { ethers, network } from 'hardhat'
+import keccak256 from 'keccak256'
 import { getConfig, Network, NetworkConfig } from '../../networkConfig'
 import { deploy } from '../utils/deploy'
 import {
@@ -176,7 +177,7 @@ describe('TalentLayer protocol global testing', function () {
       const aliceUserId = await talentLayerPlatformID.ids(alice.address)
       const alicePlatformData = await talentLayerPlatformID.platforms(aliceUserId)
       const name = alicePlatformData.name
-      const isNameTaken = await talentLayerPlatformID.takenNames(platformName)
+      const isNameTaken = await talentLayerPlatformID.takenNames(keccak256(platformName))
       const idOwner = await talentLayerPlatformID.ownerOf(platformId)
       expect(platformName).to.equal(name)
       expect(isNameTaken).to.equal(true)


### PR DESCRIPTION
# New PR: Use hash for taken handles

## Useful info

- Description: Uses the hash of the handles (instead of plain string) for checking taken handles, to optimize size and gas usage.

## Auto-Review checklist

- [X] Check if there is no merge conflict
- [X] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [X] Check lint feedbacks: `npm run lint`
- [X] Check prettier format feedbacks: `npm run format`
