### PR TITLE
Fix add expiration Date in createTransaction

### DIFF
--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -438,6 +438,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
 
         require(_msgSender() == sender, "Access denied");
         require(proposal.ownerId == _proposalId, "Incorrect proposal ID");
+        require(block.timestamp <= proposal.expirationDate, "Proposal expired");
         require(service.status == ITalentLayerService.Status.Opened, "Service status not open");
         require(proposal.status == ITalentLayerService.ProposalStatus.Pending, "Proposal status not pending");
         require(bytes(_metaEvidence).length == 46, "Invalid cid");

--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -438,7 +438,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
 
         require(_msgSender() == sender, "Access denied");
         require(proposal.ownerId == _proposalId, "Incorrect proposal ID");
-        require(block.timestamp <= proposal.expirationDate, "Proposal expired");
+        require(proposal.expirationDate >= block.timestamp, "Proposal expired");
         require(service.status == ITalentLayerService.Status.Opened, "Service status not open");
         require(proposal.status == ITalentLayerService.ProposalStatus.Pending, "Proposal status not pending");
         require(bytes(_metaEvidence).length == 46, "Invalid cid");

--- a/contracts/interfaces/ITalentLayerID.sol
+++ b/contracts/interfaces/ITalentLayerID.sol
@@ -2,6 +2,11 @@
 pragma solidity ^0.8.9;
 
 interface ITalentLayerID {
+    enum MintStatus {
+        ON_PAUSE,
+        ONLY_WHITELIST,
+        PUBLIC
+    }
     struct Profile {
         uint256 id;
         string handle;

--- a/contracts/interfaces/ITalentLayerService.sol
+++ b/contracts/interfaces/ITalentLayerService.sol
@@ -30,6 +30,7 @@ interface ITalentLayerService {
         uint256 rateAmount;
         uint16 platformId;
         string dataUri;
+        uint256 expirationDate;
     }
 
     function getService(uint256 _serviceId) external view returns (Service memory);

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -19,6 +19,7 @@ import {
   metaEvidenceCid,
   minTokenWhitelistTransactionAmount,
   MintStatus,
+  expiredProposalDate,
   proposalExpirationDate,
 } from '../utils/constant'
 
@@ -816,6 +817,28 @@ describe('TalentLayer protocol global testing', function () {
       expect(proposalDataAfter.dataUri).to.be.equal(cid2)
       expect(proposalDataAfter.ownerId).to.be.equal(bobTlId)
       expect(proposalDataAfter.status.toString()).to.be.equal('0')
+    })
+
+    it('Eve can make proposal on Alice service n°1 with a short expiration date (expired)', async function () {
+      const rateToken = '0xC01FcDfDE3B2ABA1eab76731493C617FfAED2F10'
+      const eveTid = await talentLayerID.ids(eve.address)
+      console.log('eveTid', eveTid)
+
+      const platform = await talentLayerPlatformID.getPlatform(alicePlatformId)
+      const alicePlatformProposalPostingFee = platform.servicePostingFee
+
+      // Eve creates a proposal on Platform 1 for service 1
+      await talentLayerService
+        .connect(eve)
+        .createProposal(eveTid, 1, rateToken, 15, alicePlatformId, cid2, expiredProposalDate, {
+          value: alicePlatformProposalPostingFee,
+        })
+    })
+
+    it('Alice should note be able to validate the Eve proposal after the expiration date', async function () {
+      await expect(
+        talentLayerEscrow.connect(alice).createTransaction(1, 4, metaEvidenceCid, cid2),
+      ).to.be.revertedWith('Proposal expired')
     })
 
     it('Carol can create her first proposal', async function () {

--- a/test/utils/constant.ts
+++ b/test/utils/constant.ts
@@ -5,6 +5,7 @@ export const metaEvidenceCid = 'QmQ2hcACF6r2Gf8PDxG4NcBdurzRUopwcaYQHNhSah6a8v'
 export const evidenceCid = 'QmNSARUuUMHkFcnSzrCAhmZkmQu7ViK18sPkg48xnbAmv4'
 export const now = Math.floor(Date.now() / 1000)
 export const proposalExpirationDate = now + 60 * 60 * 24 * 15
+export const expiredProposalDate = now - 60 * 60 * 24 * 30
 export const feeDivider = 10000
 export const arbitrationFeeTimeout = 3600 * 24
 


### PR DESCRIPTION
createTransaction

# New PR:

## Useful info

- Description: proposal expirationDate is not taken into account in createTransaction
- Fixed by comparing the expiration date and the blockTimestamp

## Auto-Review checklist

- [x] Check if there is no merge conflict
- [x] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [x] Check lint feedbacks: `npm run lint`
- [x] Check prettier format feedbacks: `npm run format`
