### PR TITLE
Remplaced transactions array by a mapping

### DIFF
--- a/contracts/TalentLayerPlatformID.sol
+++ b/contracts/TalentLayerPlatformID.sol
@@ -33,7 +33,7 @@ contract TalentLayerPlatformID is ERC721Upgradeable, AccessControlUpgradeable, U
     // =========================== Variables ==============================
 
     /// @notice TalentLayer Platform information struct
-    /// @param platformId the TalentLayer Platform Id
+    /// @param id the TalentLayer Platform Id
     /// @param name the name of the platform
     /// @param dataUri the IPFS URI of the Platform metadata
     /// @param originServiceFeeRate the %fee (per ten thousands) asked by the platform for each service created on the platform

--- a/test/batch/delegationSystem.ts
+++ b/test/batch/delegationSystem.ts
@@ -21,7 +21,7 @@ const carolPlatformId = 1
 const aliceTlId = 1
 const bobTlId = 2
 const serviceId = 1
-const trasactionId = 0
+const trasactionId = 1
 const transactionAmount = 100000
 const ethAddress = '0x0000000000000000000000000000000000000000'
 

--- a/test/batch/disputeResolution.ts
+++ b/test/batch/disputeResolution.ts
@@ -31,7 +31,7 @@ const daveTlId = 3
 const carolPlatformId = 1
 const serviceId = 1
 const proposalId = bobTlId
-const transactionId = 0
+const transactionId = 1
 const transactionAmount = BigNumber.from(1000000)
 const arbitrationCost = BigNumber.from(10)
 const disputeId = 0
@@ -513,6 +513,7 @@ describe('Dispute Resolution, with party failing to pay arbitration fee on time'
       const transaction = await talentLayerEscrow
         .connect(alice)
         .getTransactionDetails(transactionId)
+      expect(transaction.status).to.be.eq(TransactionStatus.Resolved)
     })
 
     it('The sender wins the dispute (Alice) receives escrow funds and gets arbitration fee reimbursed', async function () {
@@ -590,7 +591,7 @@ describe('Dispute Resolution, arbitrator abstaining from giving a ruling', funct
       halfAmount: BigNumber
 
     before(async function () {
-      tx = await talentLayerArbitrator.connect(carol).giveRuling(transactionId, 0)
+      tx = await talentLayerArbitrator.connect(carol).giveRuling(0, 0)
       halfTransactionAmount = transactionAmount.div(2)
       halfArbitrationCost = arbitrationCost.div(2)
       halfAmount = halfTransactionAmount.add(halfArbitrationCost)

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -927,7 +927,7 @@ describe('TalentLayer protocol global testing', function () {
       const amountBob = 1000000
       const amountCarol = 20000
       const serviceId = 2
-      const transactionId = 0
+      const transactionId = 1
       let proposalIdBob = 0 //Will be set later
       let proposalIdCarol = 0 //Will be set later
       let totalAmount = 0 //Will be set later
@@ -1048,7 +1048,7 @@ describe('TalentLayer protocol global testing', function () {
       it('The deposit should also update the service with transactionId, proposalId, and status.', async function () {
         const service = await talentLayerService.getService(serviceId)
         await expect(service.status.toString()).to.be.equal('1')
-        await expect(service.transactionId.toString()).to.be.equal('0')
+        await expect(service.transactionId.toString()).to.be.equal('1')
         await expect(service.acceptedProposalId).to.be.equal(proposalIdBob)
       })
 
@@ -1259,7 +1259,7 @@ describe('TalentLayer protocol global testing', function () {
       const amountBob = 1000000
       const amountCarol = 200
       const serviceId = 3
-      const transactionId = 1
+      const transactionId = 2
       let proposalIdBob = 0 //Will be set later
       let proposalIdCarol = 0 //Will be set later
       let totalAmount = 0 //Will be set later


### PR DESCRIPTION
# New PR: Remplaced transactions array by a mapping

## Useful info

- Description: Remplaced transactions array by a mapping

Index starts now at 1

Updated tests

## Auto-Review checklist

- [ ] Check if there is no merge conflict
- [ ] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [ ] Check lint feedbacks: `npm run lint`
- [ ] Check prettier format feedbacks: `npm run format`
