### PR TITLE
add safeTokenDepostir function

### DIFF
--- a/contracts/TalentLayerEscrow.sol
+++ b/contracts/TalentLayerEscrow.sol
@@ -484,10 +484,7 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
         talentLayerServiceContract.afterDeposit(_serviceId, _proposalId, transactionId);
 
         if (proposal.rateToken != address(0)) {
-            require(
-                IERC20(proposal.rateToken).transferFrom(sender, address(this), transactionAmount),
-                "Transfer must not fail"
-            );
+            _safeTokenDeposit(proposal.rateToken, transactionAmount, sender);
         }
 
         _afterCreateTransaction(service.ownerId, proposal.ownerId, transactionId, _metaEvidence);
@@ -966,6 +963,12 @@ contract TalentLayerEscrow is Initializable, ERC2771RecipientUpgradeable, UUPSUp
             talentLayerServiceContract.afterFullPayment(transaction.serviceId);
             emit PaymentCompleted(transaction.serviceId);
         }
+    }
+
+    function _safeTokenDeposit(address _token, uint256 _amount, address _sender) private {
+        uint256 balanceBefore = IERC20(_token).balanceOf(address(this));
+        require(IERC20(_token).transferFrom(_sender, address(this), _amount), "Transfer must not fail");
+        require(IERC20(_token).balanceOf(address(this)) == balanceBefore + _amount, "Invalid balance");
     }
 
     /**


### PR DESCRIPTION
Issue: ERC20 transferred value is not checked. The call could work without the correct amount to be transferred. If fewer tokens are transferred, this would lead to an incoherent state and prevent the transaction from being finalized. This issue is mitigated today by the fact that the allowed tokens are white-listed and so we will prevent taxed tokens addition. 

Cons: Add 2 new external calls