### PR TITLE
257 transferrable tl ids

### DIFF
--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -86,7 +86,7 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     /// Whether a TalentLayer ID has done some activity in the protocol (created a service or proposal)
     mapping(uint256 => bool) public hasActivity;
 
-    /// Whether a contract is a service contract, which is able to set if user has done some activity
+    /// Whether a contract is a service contract, which is able to set if a user has done some activity
     mapping(address => bool) public isServiceContract;
 
     // =========================== Errors ==============================

--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -83,8 +83,8 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     /// Maximum price for a short handle (in wei, upgradable)
     uint256 shortHandlesMaxPrice;
 
-    /// Whether a TalentLayer ID has services or proposals associated with it
-    mapping(uint256 => bool) public isSoulBound;
+    /// Whether a TalentLayer ID has done some activity in the protocol (created a service or proposal)
+    mapping(uint256 => bool) public hasActivity;
 
     // =========================== Errors ==============================
 
@@ -277,12 +277,11 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     }
 
     /**
-     * @notice Allows to set whether a TalentLayer ID is soulbound or not
+     * @notice Allows to set whether a TalentLayer ID has done some activity (created a service or proposal)
      * @param _profileId The TalentLayer ID of the user
-     * @param _isSoulBound Whether the TalentLayer ID is soulbound or not
      */
-    function setIsSoulBound(uint256 _profileId, bool _isSoulBound) external {
-        isSoulBound[_profileId] = _isSoulBound;
+    function setHasActivity(uint256 _profileId) external {
+        hasActivity[_profileId] = true;
     }
 
     // =========================== Owner functions ==============================
@@ -401,7 +400,7 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     // =========================== Overrides ==============================
 
     function _transfer(address from, address to, uint256 tokenId) internal virtual override(ERC721Upgradeable) {
-        require(!isSoulBound[tokenId], "Token transfer is not allowed");
+        require(!hasActivity[tokenId], "Token transfer is not allowed");
         require(balanceOf(to) == 0, "Receiver already has a TalentLayer ID");
         ids[from] = 0;
         ids[to] = tokenId;

--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -86,6 +86,9 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     /// Whether a TalentLayer ID has done some activity in the protocol (created a service or proposal)
     mapping(uint256 => bool) public hasActivity;
 
+    /// Whether a contract is a service contract, which is able to set if user has done some activity
+    mapping(address => bool) public isServiceContract;
+
     // =========================== Errors ==============================
 
     /**
@@ -281,6 +284,7 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
      * @param _profileId The TalentLayer ID of the user
      */
     function setHasActivity(uint256 _profileId) external {
+        require(isServiceContract[_msgSender()] == true, "Only service contracts can set whether a user has activity");
         hasActivity[_profileId] = true;
     }
 
@@ -342,6 +346,15 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     function updateShortHandlesMaxPrice(uint256 _shortHandlesMaxPrice) public onlyOwner {
         shortHandlesMaxPrice = _shortHandlesMaxPrice;
         emit ShortHandlesMaxPriceUpdated(_shortHandlesMaxPrice);
+    }
+
+    /**
+     * @notice Updates the service contract address.
+     * @param _address The address
+     * @param _isServiceContract Whether the address is a service contract
+     */
+    function setIsServiceContract(address _address, bool _isServiceContract) public onlyOwner {
+        isServiceContract[_address] = _isServiceContract;
     }
 
     // =========================== Private functions ==============================

--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -83,6 +83,9 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     /// Maximum price for a short handle (in wei, upgradable)
     uint256 shortHandlesMaxPrice;
 
+    /// Whether a TalentLayer ID has services or proposals associated with it
+    mapping(uint256 => bool) public isSoulBound;
+
     // =========================== Errors ==============================
 
     /**
@@ -273,6 +276,15 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
         emit DelegateRemoved(_profileId, _delegate);
     }
 
+    /**
+     * @notice Allows to set whether a TalentLayer ID is soulbound or not
+     * @param _profileId The TalentLayer ID of the user
+     * @param _isSoulBound Whether the TalentLayer ID is soulbound or not
+     */
+    function setIsSoulBound(uint256 _profileId, bool _isSoulBound) external {
+        isSoulBound[_profileId] = _isSoulBound;
+    }
+
     // =========================== Owner functions ==============================
 
     /**
@@ -388,32 +400,19 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
 
     // =========================== Overrides ==============================
 
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function transferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256, bytes memory) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
+    function _transfer(address from, address to, uint256 tokenId) internal virtual override(ERC721Upgradeable) {
+        require(!isSoulBound[tokenId], "Token transfer is not allowed");
+        require(balanceOf(to) == 0, "Receiver already has a TalentLayer ID");
+        ids[from] = 0;
+        ids[to] = tokenId;
+        ERC721Upgradeable._transfer(from, to, tokenId);
     }
 
     /**
      * @dev Blocks the burn function
-     * @param _tokenId The ID of the token
+     * @param tokenId The ID of the token
      */
-    function _burn(uint256 _tokenId) internal virtual override(ERC721Upgradeable) {}
+    function _burn(uint256 tokenId) internal virtual override(ERC721Upgradeable) {}
 
     /**
      * @notice Implementation of the {IERC721Metadata-tokenURI} function.

--- a/contracts/TalentLayerPlatformID.sol
+++ b/contracts/TalentLayerPlatformID.sol
@@ -505,21 +505,7 @@ contract TalentLayerPlatformID is ERC721Upgradeable, AccessControlUpgradeable, U
     /**
      * @dev Override to prevent token transfer.
      */
-    function transferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256, bytes memory) public virtual override(ERC721Upgradeable) {
+    function _transfer(address, address, uint256) internal virtual override(ERC721Upgradeable) {
         revert("Token transfer is not allowed");
     }
 

--- a/contracts/TalentLayerReview.sol
+++ b/contracts/TalentLayerReview.sol
@@ -191,21 +191,7 @@ contract TalentLayerReview is ERC2771RecipientUpgradeable, ERC721Upgradeable, UU
     /**
      * @dev Override to prevent token transfer.
      */
-    function transferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256, bytes memory) public virtual override(ERC721Upgradeable) {
+    function _transfer(address, address, uint256) internal virtual override(ERC721Upgradeable) {
         revert("Token transfer is not allowed");
     }
 

--- a/contracts/TalentLayerService.sol
+++ b/contracts/TalentLayerService.sol
@@ -263,6 +263,9 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
         service.platformId = _platformId;
         nonce[_profileId]++;
 
+        // TODO: do call only if is the first service of the user?
+        tlId.setHasActivity(_profileId);
+
         emit ServiceCreated(id, _profileId, _platformId, _dataUri);
 
         return id;
@@ -300,6 +303,9 @@ contract TalentLayerService is Initializable, ERC2771RecipientUpgradeable, UUPSU
             dataUri: _dataUri,
             expirationDate: _expirationDate
         });
+
+        // TODO: do call only if is the first service of the user?
+        tlId.setHasActivity(_profileId);
 
         emit ProposalCreated(
             _serviceId,

--- a/contracts/interfaces/ITalentLayerID.sol
+++ b/contracts/interfaces/ITalentLayerID.sol
@@ -44,5 +44,7 @@ interface ITalentLayerID {
 
     function ids(address _user) external view returns (uint256);
 
+    function setHasActivity(uint256 _profileId) external;
+
     event Mint(address indexed _user, uint256 _tokenId, string _handle);
 }

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -86,6 +86,9 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     /// Whether a TalentLayer ID has done some activity in the protocol (created a service or proposal)
     mapping(uint256 => bool) public hasActivity;
 
+    /// Whether a contract is a service contract, which is able to set if user has done some activity
+    mapping(address => bool) public isServiceContract;
+
     uint256 testVariable;
 
     // =========================== Errors ==============================
@@ -268,6 +271,7 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
      * @param _profileId The TalentLayer ID of the user
      */
     function setHasActivity(uint256 _profileId) external {
+        require(isServiceContract[_msgSender()] == true, "Only service contracts can set whether a user has activity");
         hasActivity[_profileId] = true;
     }
 
@@ -329,6 +333,15 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     function updateShortHandlesMaxPrice(uint256 _shortHandlesMaxPrice) public onlyOwner {
         shortHandlesMaxPrice = _shortHandlesMaxPrice;
         emit ShortHandlesMaxPriceUpdated(_shortHandlesMaxPrice);
+    }
+
+    /**
+     * @notice Updates the service contract address.
+     * @param _address The address
+     * @param _isServiceContract Whether the address is a service contract
+     */
+    function setIsServiceContract(address _address, bool _isServiceContract) public onlyOwner {
+        isServiceContract[_address] = _isServiceContract;
     }
 
     // =========================== Private functions ==============================

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -83,8 +83,8 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     /// Maximum price for a short handle (in wei, upgradable)
     uint256 shortHandlesMaxPrice;
 
-    /// Whether a TalentLayer ID has services or proposals associated with it
-    mapping(uint256 => bool) public isSoulBound;
+    /// Whether a TalentLayer ID has done some activity in the protocol (created a service or proposal)
+    mapping(uint256 => bool) public hasActivity;
 
     uint256 testVariable;
 
@@ -264,12 +264,11 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     }
 
     /**
-     * @notice Allows to set whether a TalentLayer ID is soulbound or not
+     * @notice Allows to set whether a TalentLayer ID has done some activity (created a service or proposal)
      * @param _profileId The TalentLayer ID of the user
-     * @param _isSoulBound Whether the TalentLayer ID is soulbound or not
      */
-    function setIsSoulBound(uint256 _profileId, bool _isSoulBound) external {
-        isSoulBound[_profileId] = _isSoulBound;
+    function setHasActivity(uint256 _profileId) external {
+        hasActivity[_profileId] = true;
     }
 
     // =========================== Owner functions ==============================
@@ -388,7 +387,7 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     // =========================== Overrides ==============================
 
     function _transfer(address from, address to, uint256 tokenId) internal virtual override(ERC721Upgradeable) {
-        require(!isSoulBound[tokenId], "Token transfer is not allowed");
+        require(!hasActivity[tokenId], "Token transfer is not allowed");
         require(balanceOf(to) == 0, "Receiver already has a TalentLayer ID");
         ids[from] = 0;
         ids[to] = tokenId;

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.9;
 
 import {ITalentLayerPlatformID} from "../interfaces/ITalentLayerPlatformID.sol";
 import {ERC2771RecipientUpgradeable} from "../libs/ERC2771RecipientUpgradeable.sol";
-
 import {Base64Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/Base64Upgradeable.sol";
 import {CountersUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
@@ -83,6 +82,9 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
 
     /// Maximum price for a short handle (in wei, upgradable)
     uint256 shortHandlesMaxPrice;
+
+    /// Whether a TalentLayer ID has services or proposals associated with it
+    mapping(uint256 => bool) public isSoulBound;
 
     uint256 testVariable;
 
@@ -261,6 +263,15 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
         emit DelegateRemoved(_profileId, _delegate);
     }
 
+    /**
+     * @notice Allows to set whether a TalentLayer ID is soulbound or not
+     * @param _profileId The TalentLayer ID of the user
+     * @param _isSoulBound Whether the TalentLayer ID is soulbound or not
+     */
+    function setIsSoulBound(uint256 _profileId, bool _isSoulBound) external {
+        isSoulBound[_profileId] = _isSoulBound;
+    }
+
     // =========================== Owner functions ==============================
 
     /**
@@ -376,32 +387,19 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
 
     // =========================== Overrides ==============================
 
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function transferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
-    }
-
-    /**
-     * @dev Override to prevent token transfer.
-     */
-    function safeTransferFrom(address, address, uint256, bytes memory) public virtual override(ERC721Upgradeable) {
-        revert("Token transfer is not allowed");
+    function _transfer(address from, address to, uint256 tokenId) internal virtual override(ERC721Upgradeable) {
+        require(!isSoulBound[tokenId], "Token transfer is not allowed");
+        require(balanceOf(to) == 0, "Receiver already has a TalentLayer ID");
+        ids[from] = 0;
+        ids[to] = tokenId;
+        ERC721Upgradeable._transfer(from, to, tokenId);
     }
 
     /**
      * @dev Blocks the burn function
-     * @param _tokenId The ID of the token
+     * @param tokenId The ID of the token
      */
-    function _burn(uint256 _tokenId) internal virtual override(ERC721Upgradeable) {}
+    function _burn(uint256 tokenId) internal virtual override(ERC721Upgradeable) {}
 
     /**
      * @notice Implementation of the {IERC721Metadata-tokenURI} function.
@@ -416,20 +414,24 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
      * @param id The ID of the token
      */
     function _buildTokenURI(uint256 id) internal view returns (string memory) {
-        string memory username = profiles[id].handle;
+        string memory username = string.concat(profiles[id].handle, ".tl");
+        string memory fontSizeStr = bytes(profiles[id].handle).length <= 20 ? "60" : "40";
 
         bytes memory image = abi.encodePacked(
             "data:image/svg+xml;base64,",
             Base64Upgradeable.encode(
                 bytes(
                     abi.encodePacked(
-                        '<svg xmlns="http://www.w3.org/2000/svg" width="720" height="720"><rect width="100%" height="100%"/><svg xmlns="http://www.w3.org/2000/svg" width="150" height="150" version="1.2" viewBox="-200 -50 1000 1000"><path fill="#FFFFFF" d="M264.5 190.5c0-13.8 11.2-25 25-25H568c13.8 0 25 11.2 25 25v490c0 13.8-11.2 25-25 25H289.5c-13.8 0-25-11.2-25-25z"/><path fill="#FFFFFF" d="M265 624c0-13.8 11.2-25 25-25h543c13.8 0 25 11.2 25 25v56.5c0 13.8-11.2 25-25 25H290c-13.8 0-25-11.2-25-25z"/><path fill="#FFFFFF" d="M0 190.5c0-13.8 11.2-25 25-25h543c13.8 0 25 11.2 25 25V247c0 13.8-11.2 25-25 25H25c-13.8 0-25-11.2-25-25z"/></svg><text x="30" y="670" style="font:60px sans-serif;fill:#fff">',
+                        '<svg xmlns="http://www.w3.org/2000/svg" width="720" height="720"><rect width="100%" height="100%"/><svg xmlns="http://www.w3.org/2000/svg" width="150" height="150" version="1.2" viewBox="-200 -50 1000 1000"><path fill="#FFFFFF" d="M264.5 190.5c0-13.8 11.2-25 25-25H568c13.8 0 25 11.2 25 25v490c0 13.8-11.2 25-25 25H289.5c-13.8 0-25-11.2-25-25z"/><path fill="#FFFFFF" d="M265 624c0-13.8 11.2-25 25-25h543c13.8 0 25 11.2 25 25v56.5c0 13.8-11.2 25-25 25H290c-13.8 0-25-11.2-25-25z"/><path fill="#FFFFFF" d="M0 190.5c0-13.8 11.2-25 25-25h543c13.8 0 25 11.2 25 25V247c0 13.8-11.2 25-25 25H25c-13.8 0-25-11.2-25-25z"/></svg><text x="30" y="670" style="font: ',
+                        fontSizeStr,
+                        'px sans-serif;fill:#fff">',
                         username,
                         "</text></svg>"
                     )
                 )
             )
         );
+
         return
             string(
                 abi.encodePacked(

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -86,7 +86,7 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     /// Whether a TalentLayer ID has done some activity in the protocol (created a service or proposal)
     mapping(uint256 => bool) public hasActivity;
 
-    /// Whether a contract is a service contract, which is able to set if user has done some activity
+    /// Whether a contract is a service contract, which is able to set if a user has done some activity
     mapping(address => bool) public isServiceContract;
 
     uint256 testVariable;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -31,6 +31,7 @@ import './scripts/tasks/protocol/set-profile-whitelist'
 import './scripts/tasks/protocol/update-profile-minting-status'
 import './scripts/tasks/protocol/update-short-handles-price'
 import './scripts/tasks/protocol/update-min-service-completion-percentage'
+import './scripts/tasks/protocol/set-is-service-contract'
 import './scripts/tasks/platform/update-signer'
 import { Network } from './networkConfig'
 

--- a/scripts/tasks/deploy/initial-setups.ts
+++ b/scripts/tasks/deploy/initial-setups.ts
@@ -1,5 +1,6 @@
 import { formatEther } from 'ethers/lib/utils'
 import { subtask, task } from 'hardhat/config'
+import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
 import { getConfig, Network, NetworkConfig } from '../../../networkConfig'
 
 /**
@@ -58,6 +59,18 @@ task(
     console.log('------------------------')
     console.log('Set profile minting status to public')
     await run('update-profile-minting-status', { mintstatus: '2' })
+    console.log('------------------------')
+
+    console.log('------------------------')
+    console.log('Set service contract address on TalentLayerID')
+    const talentLayerServiceAddress = getDeploymentProperty(
+      network.name,
+      DeploymentProperty.TalentLayerService,
+    )
+    await run('set-is-service-contract', {
+      address: talentLayerServiceAddress,
+      isServiceContract: 'true',
+    })
     console.log('------------------------')
 
     console.log('Signer')

--- a/scripts/tasks/protocol/set-is-service-contract.ts
+++ b/scripts/tasks/protocol/set-is-service-contract.ts
@@ -1,0 +1,38 @@
+import { task } from 'hardhat/config'
+import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
+
+/**
+ * @notice This task is used to set whether an address is a service contract on the TalentLayerID contract
+ * @param {address} address - The address of the contract
+ * @param {boolean} isServiceContract - Whether the address is a service contract
+ * @dev Example of script use:
+ * npx hardhat set-is-service-contract --address 0xF5b45162b92407dC1A6baF5e9316E5FF9e29f824 --is-service-contract true --network mumbai
+ */
+task('set-is-service-contract', 'Sets whether an address is a service contract.')
+  .addParam('address', "The user's address")
+  .addParam('isServiceContract', "The user's handle")
+  .setAction(async (taskArgs, { network, ethers }) => {
+    const { address, isServiceContract } = taskArgs
+
+    const talentLayerIdContract = await ethers.getContractAt(
+      'TalentLayerID',
+      getDeploymentProperty(network.name, DeploymentProperty.TalentLayerID),
+    )
+
+    if (isServiceContract !== 'true' && isServiceContract !== 'false') {
+      console.log(`Invalid input for isServiceContract: ${isServiceContract}`)
+      return
+    }
+
+    const tx = await talentLayerIdContract.setIsServiceContract(
+      address,
+      isServiceContract === 'true',
+    )
+    await tx.wait()
+
+    console.log(
+      `Address ${address} is now ${
+        isServiceContract === 'true' ? '' : 'not'
+      } set as a service contract`,
+    )
+  })

--- a/test/batch/delegationSystem.ts
+++ b/test/batch/delegationSystem.ts
@@ -58,6 +58,9 @@ async function deployAndSetup(
   // Disable whitelist for reserved handles
   await talentLayerID.connect(deployer).updateMintStatus(MintStatus.PUBLIC)
 
+  // Set service contract address on ID contract
+  await talentLayerID.connect(deployer).setIsServiceContract(talentLayerService.address, true)
+
   // Mint TL Id for Alice and Bob
   await talentLayerID.connect(alice).mint(carolPlatformId, 'alice')
   await talentLayerID.connect(bob).mint(carolPlatformId, 'bob__')

--- a/test/batch/disputeResolution.ts
+++ b/test/batch/disputeResolution.ts
@@ -88,6 +88,9 @@ async function deployAndSetup(
   // Disable whitelist for reserved handles
   await talentLayerID.connect(deployer).updateMintStatus(MintStatus.PUBLIC)
 
+  // Set service contract address on ID contract
+  await talentLayerID.connect(deployer).setIsServiceContract(talentLayerService.address, true)
+
   // Mint TL Id for Alice, Bob and Dave
   await talentLayerID.connect(alice).mint(carolPlatformId, 'alice')
   await talentLayerID.connect(bob).mint(carolPlatformId, 'bob__')

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -1717,13 +1717,11 @@ describe('TalentLayer protocol global testing', function () {
 
     it('Alice should not be able to transfer her review to carol', async function () {
       await expect(
-        talentLayerPlatformID
-          .connect(alice)
-          .transferFrom(alice.address, carol.address, aliceReviewId),
+        talentLayerReview.connect(alice).transferFrom(alice.address, carol.address, aliceReviewId),
       ).to.be.revertedWith('Token transfer is not allowed')
 
       await expect(
-        talentLayerPlatformID
+        talentLayerReview
           .connect(alice)
           ['safeTransferFrom(address,address,uint256)'](
             alice.address,
@@ -1733,7 +1731,7 @@ describe('TalentLayer protocol global testing', function () {
       ).to.be.revertedWith('Token transfer is not allowed')
 
       await expect(
-        talentLayerPlatformID
+        talentLayerReview
           .connect(alice)
           ['safeTransferFrom(address,address,uint256,bytes)'](
             alice.address,

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -495,24 +495,6 @@ describe('TalentLayer protocol global testing', function () {
       expect(profileData.platformId).to.be.equal('0')
     })
 
-    it('Alice should not be able to transfer her talentLayerId to Bob', async function () {
-      await expect(
-        talentLayerID.connect(alice).transferFrom(alice.address, bob.address, 1),
-      ).to.be.revertedWith('Token transfer is not allowed')
-
-      await expect(
-        talentLayerID
-          .connect(alice)
-          ['safeTransferFrom(address,address,uint256)'](alice.address, bob.address, 1),
-      ).to.be.revertedWith('Token transfer is not allowed')
-
-      await expect(
-        talentLayerID
-          .connect(alice)
-          ['safeTransferFrom(address,address,uint256,bytes)'](alice.address, bob.address, 1, []),
-      ).to.be.revertedWith('Token transfer is not allowed')
-    })
-
     it('The deployer can update the mint fee', async function () {
       await talentLayerID.connect(deployer).updateMintFee(mintFee)
       const updatedMintFee = await talentLayerID.mintFee()

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -117,6 +117,9 @@ describe('TalentLayer protocol global testing', function () {
 
     // Disable whitelist for reserved handles
     await talentLayerID.connect(deployer).updateMintStatus(MintStatus.PUBLIC)
+
+    // Set service contract address on ID contract
+    await talentLayerID.connect(deployer).setIsServiceContract(talentLayerService.address, true)
   })
 
   describe('Platform Id contract test', async function () {

--- a/test/batch/platformVerification.ts
+++ b/test/batch/platformVerification.ts
@@ -59,6 +59,9 @@ async function deployAndSetup(): Promise<
   // Disable whitelist for reserved handles
   await talentLayerID.connect(deployer).updateMintStatus(MintStatus.PUBLIC)
 
+  // Set service contract address on ID contract
+  await talentLayerID.connect(deployer).setIsServiceContract(talentLayerService.address, true)
+
   // Mint TL Id for Alice and Bob
   await talentLayerID.connect(alice).mint(carolPlatformId, 'alice')
   await talentLayerID.connect(bob).mint(carolPlatformId, 'bob__')

--- a/test/batch/serviceCompletion.ts
+++ b/test/batch/serviceCompletion.ts
@@ -117,7 +117,7 @@ describe('Completion of service', function () {
       let serviceStatus: ServiceStatus
 
       before(async function () {
-        const nonce = await talentLayerService.nonce(aliceTlId)
+        const nonce = await talentLayerService.serviceNonce(aliceTlId)
         serviceId = (await talentLayerService.nextServiceId()).toNumber()
 
         // Alice, the buyer, initiates a new open service

--- a/test/batch/serviceCompletion.ts
+++ b/test/batch/serviceCompletion.ts
@@ -55,6 +55,9 @@ async function deployAndSetup(): Promise<
   // Disable whitelist for reserved handles
   await talentLayerID.connect(deployer).updateMintStatus(MintStatus.PUBLIC)
 
+  // Set service contract address on ID contract
+  await talentLayerID.connect(deployer).setIsServiceContract(talentLayerService.address, true)
+
   // Mint TL Id for Alice, Bob and Dave
   await talentLayerID.connect(alice).mint(carolPlatformId, 'alice')
   await talentLayerID.connect(bob).mint(carolPlatformId, 'bob__')

--- a/test/batch/transferProfileIds.ts
+++ b/test/batch/transferProfileIds.ts
@@ -1,19 +1,33 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
-import { TalentLayerID } from '../../typechain-types'
-import { MintStatus } from '../utils/constant'
+import { TalentLayerID, TalentLayerService } from '../../typechain-types'
+import {
+  cid,
+  minTokenWhitelistTransactionAmount,
+  MintStatus,
+  proposalExpirationDate,
+} from '../utils/constant'
 import { deploy } from '../utils/deploy'
+import { getSignatureForProposal, getSignatureForService } from '../utils/signature'
 
 const evePlatformId = 1
+const serviceId = 1
+const transactionAmount = ethers.utils.parseEther('1000')
+const tokenAddress = ethers.constants.AddressZero
 
 /**
  * Deploys contracts and sets up the context for TalentLayerId contract.
  * @returns the deployed contracts
  */
-async function deployAndSetup(): Promise<[TalentLayerID]> {
-  const [talentLayerID, talentLayerPlatformID] = await deploy(false)
+async function deployAndSetup(): Promise<[TalentLayerID, TalentLayerService]> {
+  const [talentLayerID, talentLayerPlatformID, , , talentLayerService] = await deploy(false)
   const [deployer, alice, bob, carol, , eve] = await ethers.getSigners()
+
+  // Deployer whitelists a list of authorized tokens
+  await talentLayerService
+    .connect(deployer)
+    .updateAllowedTokenList(tokenAddress, true, minTokenWhitelistTransactionAmount)
 
   // Deployer mints Platform Id for Carol
   const platformName = 'hirevibes'
@@ -28,46 +42,61 @@ async function deployAndSetup(): Promise<[TalentLayerID]> {
   await talentLayerID.connect(bob).mint(evePlatformId, 'bob__')
   await talentLayerID.connect(carol).mint(evePlatformId, 'carol')
 
-  return [talentLayerID]
+  // Set service contract address on ID contract
+  await talentLayerID.connect(deployer).setIsServiceContract(talentLayerService.address, true)
+
+  return [talentLayerID, talentLayerService]
 }
 
 describe('Transfer of TalentLayer IDs', function () {
   let talentLayerID: TalentLayerID,
+    talentLayerService: TalentLayerService,
     alice: SignerWithAddress,
     bob: SignerWithAddress,
     carol: SignerWithAddress,
-    dave: SignerWithAddress
+    dave: SignerWithAddress,
+    eve: SignerWithAddress
 
   before(async function () {
-    ;[, alice, bob, carol, dave] = await ethers.getSigners()
-    ;[talentLayerID] = await deployAndSetup()
+    ;[, alice, bob, carol, dave, eve] = await ethers.getSigners()
+    ;[talentLayerID, talentLayerService] = await deployAndSetup()
   })
 
   it('A new TalentLayer ID can be initially transferred', async function () {
+    // Alice transfers her TL Id to Dave, who doesn't have a TL Id yet
     const aliceTlId = await talentLayerID.ids(alice.address)
     await talentLayerID.connect(alice).transferFrom(alice.address, dave.address, 1)
 
     const daveTlId = await talentLayerID.ids(dave.address)
     const aliceTlIdAfter = await talentLayerID.ids(alice.address)
 
+    // Check that Dave now owns Alice's TL Id
     expect(await talentLayerID.ownerOf(aliceTlId)).to.equal(dave.address)
     expect(daveTlId).to.equal(aliceTlId)
 
+    // Check that Alice no longer owns her TL Id
     expect(await talentLayerID.balanceOf(alice.address)).to.equal(0)
     expect(aliceTlIdAfter).to.equal(0)
   })
 
   it("A TalentLayer ID can't be transferred to an address who already has a TalentLayer ID", async function () {
+    // BOb tries to transfer his TL Id to Carol, who already has a TL Id
     const bobTlId = await talentLayerID.ids(bob.address)
     const tx = talentLayerID.connect(bob).transferFrom(bob.address, carol.address, bobTlId)
 
     expect(tx).to.be.revertedWith('Receiver already has a TalentLayer ID')
   })
 
-  it("A TalentLayer ID can't be transferred anymore after it has done some activity in the protocol", async function () {
+  it("A TalentLayer ID can't be transferred anymore after it has created a service", async function () {
     const bobTlId = await talentLayerID.ids(bob.address)
-    await talentLayerID.connect(bob).setHasActivity(bobTlId)
 
+    // Bob creates a new service
+    const signature = await getSignatureForService(eve, bobTlId.toNumber(), 0, cid)
+    await talentLayerService.connect(bob).createService(bobTlId, evePlatformId, cid, signature)
+
+    expect(await talentLayerID.hasActivity(bobTlId)).to.be.true
+
+    // Bob tries to transfer his TL Id to Dave
     await expect(
       talentLayerID.connect(bob).transferFrom(bob.address, dave.address, bobTlId),
     ).to.be.revertedWith('Token transfer is not allowed')
@@ -82,6 +111,49 @@ describe('Transfer of TalentLayer IDs', function () {
       talentLayerID
         .connect(bob)
         ['safeTransferFrom(address,address,uint256,bytes)'](bob.address, dave.address, bobTlId, []),
+    ).to.be.revertedWith('Token transfer is not allowed')
+  })
+
+  it("A TalentLayer ID can't be transferred anymore after it has created a proposal", async function () {
+    const carolTlId = await talentLayerID.ids(carol.address)
+
+    // Carol creates a proposal
+    const signature = await getSignatureForProposal(eve, carolTlId.toNumber(), 1, cid)
+    await talentLayerService
+      .connect(carol)
+      .createProposal(
+        carolTlId,
+        serviceId,
+        tokenAddress,
+        transactionAmount,
+        evePlatformId,
+        cid,
+        proposalExpirationDate,
+        signature,
+      )
+
+    expect(await talentLayerID.hasActivity(carolTlId)).to.be.true
+
+    // Carol tries to transfer her TL Id to Dave
+    await expect(
+      talentLayerID.connect(carol).transferFrom(carol.address, dave.address, carolTlId),
+    ).to.be.revertedWith('Token transfer is not allowed')
+
+    await expect(
+      talentLayerID
+        .connect(carol)
+        ['safeTransferFrom(address,address,uint256)'](carol.address, dave.address, carolTlId),
+    ).to.be.revertedWith('Token transfer is not allowed')
+
+    await expect(
+      talentLayerID
+        .connect(carol)
+        ['safeTransferFrom(address,address,uint256,bytes)'](
+          carol.address,
+          dave.address,
+          carolTlId,
+          [],
+        ),
     ).to.be.revertedWith('Token transfer is not allowed')
   })
 })

--- a/test/batch/transferProfileIds.ts
+++ b/test/batch/transferProfileIds.ts
@@ -64,9 +64,9 @@ describe('Transfer of TalentLayer IDs', function () {
     expect(tx).to.be.revertedWith('Receiver already has a TalentLayer ID')
   })
 
-  it("A TalentLayer ID can't be transferred anymore after it's marked as soulbound", async function () {
+  it("A TalentLayer ID can't be transferred anymore after it has done some activity in the protocol", async function () {
     const bobTlId = await talentLayerID.ids(bob.address)
-    await talentLayerID.connect(bob).setIsSoulBound(bobTlId, true)
+    await talentLayerID.connect(bob).setHasActivity(bobTlId)
 
     await expect(
       talentLayerID.connect(bob).transferFrom(bob.address, dave.address, bobTlId),

--- a/test/batch/transferProfileIds.ts
+++ b/test/batch/transferProfileIds.ts
@@ -156,4 +156,18 @@ describe('Transfer of TalentLayer IDs', function () {
         ),
     ).to.be.revertedWith('Token transfer is not allowed')
   })
+
+  it('Only service contracts can set whether a user has done an activity', async function () {
+    const carolTlId = await talentLayerID.ids(carol.address)
+
+    // Carol tries to set her activity status
+    await expect(talentLayerID.connect(carol).setHasActivity(carolTlId)).to.be.revertedWith(
+      'Only service contracts can set whether a user has activity',
+    )
+
+    // Dave tries to set Carol's activity status
+    await expect(talentLayerID.connect(dave).setHasActivity(carolTlId)).to.be.revertedWith(
+      'Only service contracts can set whether a user has activity',
+    )
+  })
 })

--- a/test/batch/transferProfileIds.ts
+++ b/test/batch/transferProfileIds.ts
@@ -1,0 +1,87 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { TalentLayerID } from '../../typechain-types'
+import { MintStatus } from '../utils/constant'
+import { deploy } from '../utils/deploy'
+
+const evePlatformId = 1
+
+/**
+ * Deploys contracts and sets up the context for TalentLayerId contract.
+ * @returns the deployed contracts
+ */
+async function deployAndSetup(): Promise<[TalentLayerID]> {
+  const [talentLayerID, talentLayerPlatformID] = await deploy(false)
+  const [deployer, alice, bob, carol, , eve] = await ethers.getSigners()
+
+  // Deployer mints Platform Id for Carol
+  const platformName = 'hirevibes'
+  await talentLayerPlatformID.connect(deployer).whitelistUser(deployer.address)
+  await talentLayerPlatformID.connect(deployer).mintForAddress(platformName, eve.address)
+
+  // Disable whitelist for reserved handles
+  await talentLayerID.connect(deployer).updateMintStatus(MintStatus.PUBLIC)
+
+  // Mint TL Id for Alice, Bob and Dave
+  await talentLayerID.connect(alice).mint(evePlatformId, 'alice')
+  await talentLayerID.connect(bob).mint(evePlatformId, 'bob__')
+  await talentLayerID.connect(carol).mint(evePlatformId, 'carol')
+
+  return [talentLayerID]
+}
+
+describe('Transfer of TalentLayer IDs', function () {
+  let talentLayerID: TalentLayerID,
+    alice: SignerWithAddress,
+    bob: SignerWithAddress,
+    carol: SignerWithAddress,
+    dave: SignerWithAddress
+
+  before(async function () {
+    ;[, alice, bob, carol, dave] = await ethers.getSigners()
+    ;[talentLayerID] = await deployAndSetup()
+  })
+
+  it('A new TalentLayer ID can be initially transferred', async function () {
+    const aliceTlId = await talentLayerID.ids(alice.address)
+    await talentLayerID.connect(alice).transferFrom(alice.address, dave.address, 1)
+
+    const daveTlId = await talentLayerID.ids(dave.address)
+    const aliceTlIdAfter = await talentLayerID.ids(alice.address)
+
+    expect(await talentLayerID.ownerOf(aliceTlId)).to.equal(dave.address)
+    expect(daveTlId).to.equal(aliceTlId)
+
+    expect(await talentLayerID.balanceOf(alice.address)).to.equal(0)
+    expect(aliceTlIdAfter).to.equal(0)
+  })
+
+  it("A TalentLayer ID can't be transferred to an address who already has a TalentLayer ID", async function () {
+    const bobTlId = await talentLayerID.ids(bob.address)
+    const tx = talentLayerID.connect(bob).transferFrom(bob.address, carol.address, bobTlId)
+
+    expect(tx).to.be.revertedWith('Receiver already has a TalentLayer ID')
+  })
+
+  it("A TalentLayer ID can't be transferred anymore after it's marked as soulbound", async function () {
+    const bobTlId = await talentLayerID.ids(bob.address)
+    await talentLayerID.connect(bob).setIsSoulBound(bobTlId, true)
+
+    await expect(
+      talentLayerID.connect(bob).transferFrom(bob.address, dave.address, bobTlId),
+    ).to.be.revertedWith('Token transfer is not allowed')
+
+    await expect(
+      talentLayerID
+        .connect(bob)
+        ['safeTransferFrom(address,address,uint256)'](bob.address, dave.address, bobTlId),
+    ).to.be.revertedWith('Token transfer is not allowed')
+
+    await expect(
+      talentLayerID
+        .connect(bob)
+        ['safeTransferFrom(address,address,uint256,bytes)'](bob.address, dave.address, bobTlId, []),
+    ).to.be.revertedWith('Token transfer is not allowed')
+  })
+})


### PR DESCRIPTION
# New PR:

## Useful info

- Trello: https://trello.com/c/1zkuDMko/257-tlid-without-service-proposal-transferrable
- Description: Makes TL ids transferrable until the profile has done some activity in the protocol (either create a service or a proposal). It's the responsibility of service contracts to set whether a profile has done some activity or not.

## Auto-Review checklist

- [X] Check if there is no merge conflict
- [X] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [X] Check lint feedbacks: `npm run lint`
- [X] Check prettier format feedbacks: `npm run format`
