### PR TITLE
Mint TL id for address

### DIFF
--- a/contracts/TalentLayerID.sol
+++ b/contracts/TalentLayerID.sol
@@ -230,6 +230,22 @@ contract TalentLayerID is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPSUp
     }
 
     /**
+     * @notice Allows a user to mint a new TalentLayerID for another address, paying the fee.
+     * @param _address Address to mint the TalentLayer ID for
+     * @param _handle Handle for the user
+     * @param _platformId Platform ID mint the id from
+     */
+    function mintForAddress(
+        address _address,
+        uint256 _platformId,
+        string calldata _handle
+    ) public payable canMint(_address, _handle, _platformId) canPay(_handle) returns (uint256) {
+        require(mintStatus == MintStatus.PUBLIC, "Public mint is not enabled");
+        _safeMint(_address, nextProfileId.current());
+        return _afterMint(_address, _handle, _platformId, msg.value);
+    }
+
+    /**
      * @notice Allows users who reserved a handle to mint a new TalentLayerID.
      * @param _handle Handle for the user
      * @param _platformId Platform ID mint the id from

--- a/contracts/interfaces/ITalentLayerID.sol
+++ b/contracts/interfaces/ITalentLayerID.sol
@@ -18,6 +18,12 @@ interface ITalentLayerID {
 
     function mint(string memory _handle) external returns (uint256);
 
+    function mintForAddress(
+        address _address,
+        uint256 _platformId,
+        string calldata _handle
+    ) external payable returns (uint256);
+
     function updateProfileData(uint256 _tokenId, string memory _newCid) external;
 
     function freeMint(uint256 _platformId, address _userAddress, string calldata _handle) external returns (uint256);

--- a/contracts/tests/TalentLayerIDV2.sol
+++ b/contracts/tests/TalentLayerIDV2.sol
@@ -217,6 +217,22 @@ contract TalentLayerIDV2 is ERC2771RecipientUpgradeable, ERC721Upgradeable, UUPS
     }
 
     /**
+     * @notice Allows a user to mint a new TalentLayerID for another address, paying the fee.
+     * @param _address Address to mint the TalentLayer ID for
+     * @param _handle Handle for the user
+     * @param _platformId Platform ID mint the id from
+     */
+    function mintForAddress(
+        address _address,
+        uint256 _platformId,
+        string calldata _handle
+    ) public payable canMint(_address, _handle, _platformId) canPay(_handle) returns (uint256) {
+        require(mintStatus == MintStatus.PUBLIC, "Public mint is not enabled");
+        _safeMint(_address, nextProfileId.current());
+        return _afterMint(_address, _handle, _platformId, msg.value);
+    }
+
+    /**
      * @notice Allows users who reserved a handle to mint a new TalentLayerID.
      * @param _handle Handle for the user
      * @param _platformId Platform ID mint the id from

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,7 @@ import './scripts/tasks/protocol/update-short-handles-price'
 import './scripts/tasks/protocol/update-min-service-completion-percentage'
 import './scripts/tasks/protocol/set-is-service-contract'
 import './scripts/tasks/platform/update-signer'
+import './scripts/tasks/platform/mint-for-address'
 import { Network } from './networkConfig'
 
 const mnemonic: string | undefined = process.env.MNEMONIC

--- a/scripts/tasks/platform/mint-for-address.ts
+++ b/scripts/tasks/platform/mint-for-address.ts
@@ -1,0 +1,38 @@
+import { task } from 'hardhat/config'
+import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/deploymentManager'
+
+/**
+ * @notice This task is used to mint a new TalentLayer ID for a user with a given address
+ * @param {string} address - The wallet address of the user
+ * @param {string} handle - The handle of the user
+ * @dev Example of script use: "npx hardhat mint-for-address --address 0x5FbDB2315678afecb367f032d93F642f64180aa3 --network mumbai"
+ */
+task('mint-for-address', 'Mints a new TalentLayer ID for a given address')
+  .addParam('address', "The user's address")
+  .addParam('handle', "The user's handle")
+  .setAction(async (taskArgs, { ethers, network }) => {
+    const { address, handle } = taskArgs
+    const [deployer] = await ethers.getSigners()
+
+    console.log('network', network.name)
+
+    const platformIdContract = await ethers.getContractAt(
+      'TalentLayerPlatformID',
+      getDeploymentProperty(network.name, DeploymentProperty.TalentLayerPlatformID),
+      deployer,
+    )
+    const talentLayerIdContract = await ethers.getContractAt(
+      'TalentLayerID',
+      getDeploymentProperty(network.name, DeploymentProperty.TalentLayerID),
+      deployer,
+    )
+
+    const platformId = await platformIdContract.ids(deployer.address)
+
+    const tx = await talentLayerIdContract
+      .connect(deployer)
+      .mintForAddress(address, platformId, handle)
+    await tx.wait()
+
+    console.log(`Minted TalentLayer ID with handle ${handle} for address ${address}`)
+  })

--- a/scripts/tasks/platform/mint-for-address.ts
+++ b/scripts/tasks/platform/mint-for-address.ts
@@ -29,9 +29,12 @@ task('mint-for-address', 'Mints a new TalentLayer ID for a given address')
 
     const platformId = await platformIdContract.ids(deployer.address)
 
+    const price = await talentLayerIdContract.getHandlePrice(handle)
     const tx = await talentLayerIdContract
       .connect(deployer)
-      .mintForAddress(address, platformId, handle)
+      .mintForAddress(address, platformId, handle, {
+        value: price,
+      })
     await tx.wait()
 
     console.log(`Minted TalentLayer ID with handle ${handle} for address ${address}`)

--- a/scripts/tasks/platform/mint-for-address.ts
+++ b/scripts/tasks/platform/mint-for-address.ts
@@ -5,7 +5,7 @@ import { DeploymentProperty, getDeploymentProperty } from '../../../.deployment/
  * @notice This task is used to mint a new TalentLayer ID for a user with a given address
  * @param {string} address - The wallet address of the user
  * @param {string} handle - The handle of the user
- * @dev Example of script use: "npx hardhat mint-for-address --address 0x5FbDB2315678afecb367f032d93F642f64180aa3 --network mumbai"
+ * @dev Example of script use: "npx hardhat mint-for-address --address 0x5FbDB2315678afecb367f032d93F642f64180aa3 --handle miguel --network mumbai"
  */
 task('mint-for-address', 'Mints a new TalentLayer ID for a given address')
   .addParam('address', "The user's address")

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -553,25 +553,31 @@ describe('TalentLayer protocol global testing', function () {
     })
 
     it('Eve can mint a talentLayerId by paying the mint fee', async function () {
-      const eveBalanceBefore = await eve.getBalance()
-      const contractBalanceBefore = await ethers.provider.getBalance(talentLayerID.address)
-
       // Mint fails if not enough ETH is sent
       await expect(talentLayerID.connect(eve).mint('1', 'eve__')).to.be.revertedWith(
         'Incorrect amount of ETH for mint fee',
       )
 
       // Mint is successful if the correct amount of ETH for mint fee is sent
-      await talentLayerID.connect(eve).mint('1', 'eve__', { value: mintFee })
+      const tx = await talentLayerID.connect(eve).mint('1', 'eve__', { value: mintFee })
       expect(await talentLayerID.ids(eve.address)).to.be.equal('4')
 
-      // Eve balance is decreased by the mint fee (+ gas fees)
-      const eveBalanceAfter = await eve.getBalance()
-      expect(eveBalanceAfter).to.be.lte(eveBalanceBefore.sub(mintFee))
+      await expect(tx).to.changeEtherBalances([eve, talentLayerID], [-mintFee, mintFee])
+    })
 
-      // TalentLayer id contract balance is increased by the mint fee
-      const contractBalanceAfter = await ethers.provider.getBalance(talentLayerID.address)
-      expect(contractBalanceAfter).to.be.equal(contractBalanceBefore.add(mintFee))
+    it('Alice can mint a talentLayerId for Frank by paying the mint fee', async function () {
+      // Mint fails if not enough ETH is sent
+      await expect(
+        talentLayerID.connect(alice).mintForAddress(frank.address, '1', 'frank'),
+      ).to.be.revertedWith('Incorrect amount of ETH for mint fee')
+
+      // Mint is successful if the correct amount of ETH for mint fee is sent
+      const tx = await talentLayerID
+        .connect(alice)
+        .mintForAddress(frank.address, '1', 'frank', { value: mintFee })
+
+      expect(await talentLayerID.ids(frank.address)).to.be.equal('5')
+      await expect(tx).to.changeEtherBalances([alice, talentLayerID], [-mintFee, mintFee])
     })
 
     it("The deployer can withdraw the contract's balance", async function () {

--- a/test/batch/fullWorkflow.ts
+++ b/test/batch/fullWorkflow.ts
@@ -596,14 +596,6 @@ describe('TalentLayer protocol global testing', function () {
       )
     })
 
-    it('Withdraw', async function () {
-      // Withdraw is successful if the caller is the owner
-      const tx = await talentLayerID.connect(deployer).withdraw()
-      await tx.wait()
-
-      await expect(tx).to.not.be.reverted
-    })
-
     it('Deployer can mint TalentLayerID', async function () {
       const tx = await talentLayerID.freeMint('1', grace.address, 'grace')
       await expect(tx).to.changeEtherBalances([deployer, grace], [0, 0])


### PR DESCRIPTION
# New PR: Mint TL id for address

## Useful info

- Trello: https://trello.com/c/PmvUBBpH/271-mintforaddress-tlid
- Description: Allows any address to mint a TalentLayer id for another address, covering the fee.

## Auto-Review checklist

- [X] Check if there is no merge conflict
- [X] If you have new .env variable, check if you add it in the .env.example file

## Typing

- [X] Check lint feedbacks: `npm run lint`
- [X] Check prettier format feedbacks: `npm run format`
